### PR TITLE
Add testing structure for doing separate Trio and Asyncio tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,30 +48,72 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: lint
+  py36-asyncio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-asyncio
   py36-core:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-core
+  py36-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-trio
+  py37-asyncio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-asyncio
   py37-core:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py37-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-trio
+  pypy3-asyncio:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3-asyncio
   pypy3-core:
     <<: *common
     docker:
       - image: pypy
         environment:
           TOXENV: pypy3-core
+  pypy3-trio:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3-trio
 workflows:
   version: 2
   test:
     jobs:
       - doctest
       - lint
+      - py36-asyncio
       - py36-core
+      - py36-trio
+      - py37-asyncio
       - py37-core
+      - py37-trio
+      - pypy3-asyncio
       - pypy3-core
+      - pypy3-trio

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,12 @@ extras_require = {
         "pytest-xdist",
         "tox>=2.9.1,<3",
     ],
+    'test-asyncio': [
+        "pytest-asyncio>=0.10.0,<0.11",
+    ],
+    'test-trio': [
+        "pytest-trio==0.5.2",
+    ],
     'lint': [
         "black==19.3b",
         "flake8==3.4.1",
@@ -55,6 +61,8 @@ setup(
     url='https://github.com/ethereum/async-service',
     include_package_data=True,
     install_requires=[
+        "trio>=0.13,<14",
+        "trio-typing>=0.3,<0.4",
     ],
     python_requires='>=3.6, <4',
     extras_require=extras_require,

--- a/tests-asyncio/test_basic_asyncio.py
+++ b/tests-asyncio/test_basic_asyncio.py
@@ -1,0 +1,9 @@
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_basic_asyncio():
+    await asyncio.sleep(0)
+    assert True

--- a/tests-trio/test_basic_trio.py
+++ b/tests-trio/test_basic_trio.py
@@ -1,0 +1,9 @@
+import trio
+
+import pytest
+
+
+@pytest.mark.trio
+async def test_basic_trio():
+    await trio.sleep(0)
+    assert True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37,py3}-core
+    py{36,37,py3}-{asyncio,core,trio}
     lint
     doctest
 
@@ -24,6 +24,9 @@ ignore= W503
 usedevelop=True
 commands=
     core: pytest {posargs:tests/core}
+    core: pytest {posargs:tests/core}
+    asyncio: pytest {posargs:tests-asyncio}
+    trio: pytest {posargs:tests-trio}
     doctest: make -C {toxinidir}/docs doctest
 basepython =
     doctest: python
@@ -32,6 +35,8 @@ basepython =
     pypy3: pypy3
 extras=
     test
+    asyncio: test-asyncio
+    trio: test-trio
     doctest: doc
 whitelist_externals=make
 
@@ -39,7 +44,7 @@ whitelist_externals=make
 basepython=python
 extras=lint
 commands=
-    mypy -p {toxinidir}/async_service --config-file {toxinidir}/mypy.ini
+    mypy -p async_service --config-file {toxinidir}/mypy.ini
     flake8 {toxinidir}/async_service {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/async_service {toxinidir}/tests
     pydocstyle {toxinidir}/async_service {toxinidir}/tests


### PR DESCRIPTION
## What was wrong?

Library needs to test both `trio` and `asyncio` based stuff.

## How was it fixed?

Segregation under `./tests-asyncio` and `./tests-trio`

#### Cute Animal Picture

![Harp-seal-pup -Photo-credit](https://user-images.githubusercontent.com/824194/69269586-987fdf00-0b8e-11ea-8c47-c3d671936ca4.jpg)

