### PR TITLE
expose type hints to 3rd party installers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
     zip_safe=False,
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={'async_service': ['py.typed']},
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
## What was wrong?

Not exposing type hints

## How was it fixed?

expose them

#### Cute Animal Picture

![Blakeney-48web](https://user-images.githubusercontent.com/824194/69448695-5386b480-0d16-11ea-860c-853d1f5eadc6.jpg)

