### PR TITLE
Fix name in task logging and emit extra logging message when starting a task.

### DIFF
--- a/async_service/_utils.py
+++ b/async_service/_utils.py
@@ -1,7 +1,36 @@
 import itertools
-from typing import Collection, Iterable, Mapping, Set, TypeVar
+from typing import Any, Collection, Iterable, Mapping, Set, TypeVar
 
 TItem = TypeVar("TItem")
+
+
+def get_task_name(value: Any, explicit_name: str = None) -> str:
+    # inline import to ensure `_utils` is always importable from the rest of
+    # the module.
+    from .abc import ManagerAPI, ServiceAPI  # noqa: F401
+
+    if explicit_name is not None:
+        # if an explicit name was provided, just return that.
+        return explicit_name
+    elif isinstance(value, ServiceAPI):
+        # `Service` instance nameing rules:
+        #
+        # 1. __str__ **if** the class implements a custom __str__ method
+        # 2. __repr__ **if** the class implements a custom __repr__ method
+        # 3. The `Service` class name.
+        value_cls = type(value)
+        if value_cls.__str__ is not object.__str__:
+            return str(value)
+        if value_cls.__repr__ is not object.__repr__:
+            return repr(value)
+        else:
+            return value.__class__.__name__
+    else:
+        try:
+            # Prefer the name of the function if it has one
+            return str(value.__name__)  # mypy doesn't know __name__ is a `str`
+        except AttributeError:
+            return repr(value)
 
 
 def iter_dag(dag: Mapping[TItem, Collection[TItem]]) -> Iterable[TItem]:

--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -210,6 +210,7 @@ class AsyncioManager(BaseManager):
         daemon: bool,
         name: str,
     ) -> None:
+        self.logger.debug("running task '%s[daemon=%s]'", name, daemon)
         try:
             await async_fn(*args)
         except asyncio.CancelledError:

--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -246,10 +246,11 @@ class AsyncioManager(BaseManager):
         current_task = asyncio.Task.current_task()
         if not _root and current_task not in self._service_task_dag:
             raise Exception(f"TODO: unknown task {current_task}")
+        if name is None:
+            name = repr(async_fn)
+
         task = asyncio.ensure_future(
-            self._run_and_manage_task(
-                async_fn, *args, daemon=daemon, name=name or repr(async_fn)
-            ),
+            self._run_and_manage_task(async_fn, *args, daemon=daemon, name=name),
             loop=self._loop,
         )
         self._service_task_dag[task] = []
@@ -260,7 +261,9 @@ class AsyncioManager(BaseManager):
         self, service: ServiceAPI, daemon: bool = False, name: str = None
     ) -> ManagerAPI:
         child_manager = type(self)(service, loop=self._loop)
-        self.run_task(child_manager.run, daemon=daemon, name=name or repr(service))
+        if name is None:
+            name = repr(service)
+        self.run_task(child_manager.run, daemon=daemon, name=name)
         return child_manager
 
 

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -184,6 +184,7 @@ class TrioManager(BaseManager):
         daemon: bool,
         name: str,
     ) -> None:
+        self.logger.debug("running task '%s[daemon=%s]'", name, daemon)
         try:
             await async_fn(*args)
         except Exception as err:

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -215,10 +215,10 @@ class TrioManager(BaseManager):
         name: str = None,
     ) -> None:
 
+        if name is None:
+            name = repr(async_fn)
         self._task_nursery.start_soon(
-            functools.partial(
-                self._run_and_manage_task, daemon=daemon, name=name or repr(async_fn)
-            ),
+            functools.partial(self._run_and_manage_task, daemon=daemon, name=name),
             async_fn,
             *args,
             name=name,
@@ -228,7 +228,9 @@ class TrioManager(BaseManager):
         self, service: ServiceAPI, daemon: bool = False, name: str = None
     ) -> ManagerAPI:
         child_manager = type(self)(service)
-        self.run_task(child_manager.run, daemon=daemon, name=name or repr(service))
+        if name is None:
+            name = repr(service)
+        self.run_task(child_manager.run, daemon=daemon, name=name)
         return child_manager
 
 

--- a/tests/core/test_get_task_name.py
+++ b/tests/core/test_get_task_name.py
@@ -1,0 +1,60 @@
+import pytest
+
+from async_service import Service
+from async_service._utils import get_task_name
+
+
+async def async_fn_for_test():
+    pass
+
+
+class NoStrOrRepr(Service):
+    async def run(self):
+        pass
+
+
+class HasStrNotRepr(Service):
+    def __str__(self):
+        return "custom-str"
+
+    async def run(self):
+        pass
+
+
+class HasReprNotStr(Service):
+    def __repr__(self):
+        return "custom-repr"
+
+    async def run(self):
+        pass
+
+
+class HasStrAndRepr(Service):
+    def __str__(self):
+        return "custom-str"
+
+    def __repr__(self):
+        return "custom-repr"
+
+    async def run(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    "value,explicit_name,expected_name",
+    (
+        (async_fn_for_test, None, "async_fn_for_test"),
+        (async_fn_for_test, "explicit_0", "explicit_0"),
+        (NoStrOrRepr(), None, "NoStrOrRepr"),
+        (NoStrOrRepr(), "explicit_1", "explicit_1"),
+        (HasStrNotRepr(), None, "custom-str"),
+        (HasStrNotRepr(), "explicit_2", "explicit_2"),
+        (HasReprNotStr(), None, "custom-repr"),
+        (HasReprNotStr(), "explicit_3", "explicit_3"),
+        (HasStrAndRepr(), None, "custom-str"),
+        (HasStrAndRepr(), "explicit_4", "explicit_4"),
+    ),
+)
+def test_get_task_name(value, explicit_name, expected_name):
+    task_name = get_task_name(value, explicit_name)
+    assert task_name == expected_name


### PR DESCRIPTION
## What was wrong?

The logging message emitted when running a task always uses `repr(async_fn)` even if an explicit `name` is provided.

Also there is no logging message emitted before running a task which is a nice thing to have for debugging.

## How was it fixed?

Fixed logic to use the explicit name when provided.

Also added a logging statement before the task runs (this proved useful in debugging)

#### Cute Animal Picture

![o-DOG-CHRISTMAS-facebook](https://user-images.githubusercontent.com/824194/70755794-0cc62200-1cf8-11ea-8022-6e5a895783fa.jpg)
