### PR TITLE
Update asyncio external_api and expand tests

### DIFF
--- a/async_service/__init__.py
+++ b/async_service/__init__.py
@@ -1,5 +1,9 @@
 from .abc import ManagerAPI, ServiceAPI  # noqa: F401
-from .asyncio import AsyncioManager, background_asyncio_service  # noqa: F401
+from .asyncio import (  # noqa: F401
+    AsyncioManager,
+    background_asyncio_service,
+    external_api as external_asyncio_api,
+)
 from .base import Service, as_service  # noqa: F401
 from .exceptions import DaemonTaskExit, LifecycleError, ServiceCancelled  # noqa: F401
 from .trio import TrioManager, background_trio_service  # noqa: F401

--- a/tests-asyncio/test_asyncio_external_api.py
+++ b/tests-asyncio/test_asyncio_external_api.py
@@ -6,20 +6,94 @@ from async_service import Service, ServiceCancelled, background_asyncio_service
 from async_service.asyncio import external_api
 
 
+class ExternalAPIService(Service):
+    async def run(self):
+        await self.manager.wait_finished()
+
+    @external_api
+    async def get_7(self, wait_return=None, signal_event=None):
+        if signal_event is not None:
+            signal_event.set()
+        if wait_return is not None:
+            await wait_return.wait()
+        return 7
+
+
 @pytest.mark.asyncio
-async def test_asyncio_service_external_api_raises_ServiceCancelled():
-    class ServiceTest(Service):
-        async def run(self):
-            await self.manager.wait_finished()
+async def test_asyncio_service_external_api_fails_before_start():
+    service = ExternalAPIService()
 
-        @external_api
-        async def get_7(self):
-            await asyncio.sleep(1)
-            return 7
-
-    service = ServiceTest()
-    async with background_asyncio_service(service) as manager:
-        manager.cancel()
-
+    # should raise if the service has not yet been started.
     with pytest.raises(ServiceCancelled):
         await service.get_7()
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_external_api_works_while_running():
+    service = ExternalAPIService()
+
+    async with background_asyncio_service(service):
+        assert await service.get_7() == 7
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_external_api_race_condition_done_and_cancelled():
+    service = ExternalAPIService()
+
+    async with background_asyncio_service(service) as manager:
+        task = asyncio.ensure_future(service.get_7())
+
+        # wait for the task to be done (but don't fetch the result yet)
+        await asyncio.wait((task,))
+
+        # now cancel the service
+        manager.cancel()
+
+        # Since the task was already done it should return the result even
+        # though the service was just canceled
+        assert await task == 7
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_external_api_raises_when_cancelled():
+    service = ExternalAPIService()
+
+    async with background_asyncio_service(service) as manager:
+        # an event to ensure that we are indeed within the body of the
+        is_within_fn = asyncio.Event()
+        trigger_return = asyncio.Event()
+
+        task = asyncio.ensure_future(
+            service.get_7(wait_return=trigger_return, signal_event=is_within_fn)
+        )
+
+        # ensure we're within the body of the task.
+        await is_within_fn.wait()
+
+        # now cancel the service and trigger the return of the function.
+        manager.cancel()
+
+        # Since the task is in the middle of executing it wn't be done and thus
+        # this should fail.  This should be hitting the `asyncio.wait(...)`
+        # mechanism.
+        with pytest.raises(ServiceCancelled):
+            assert await task == 7
+
+        # A direct call should also fail.  This *should* be hitting the early
+        # return mechanism.
+        with pytest.raises(ServiceCancelled):
+            assert await service.get_7()
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_external_api_raises_when_finished():
+    service = ExternalAPIService()
+
+    async with background_asyncio_service(service) as manager:
+        pass
+
+    assert manager.is_finished
+    # A direct call should also fail.  This *should* be hitting the early
+    # return mechanism.
+    with pytest.raises(ServiceCancelled):
+        assert await service.get_7()

--- a/tests/typing-checks/test_core_api.py
+++ b/tests/typing-checks/test_core_api.py
@@ -1,0 +1,17 @@
+from async_service import Service
+from async_service.asyncio import external_api
+
+
+class MyService(Service):
+    async def run(self) -> None:
+        pass
+
+    @external_api
+    async def return_7(self) -> int:
+        return 7
+
+
+async def ensure_type_external_api() -> int:
+    service = MyService()
+
+    return await service.return_7()

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,7 @@ basepython=python
 extras=lint
 commands=
     mypy -p async_service --config-file {toxinidir}/mypy.ini
+    mypy --config-file {toxinidir}/mypy.ini tests/typing-checks/
     flake8 {toxinidir}/async_service {toxinidir}/tests {toxinidir}/tests-asyncio {toxinidir}/tests-trio
     isort --recursive --check-only --diff {toxinidir}/async_service {toxinidir}/tests {toxinidir}/tests-asyncio {toxinidir}/tests-trio
     pydocstyle {toxinidir}/async_service {toxinidir}/tests {toxinidir}/tests-asyncio {toxinidir}/tests-trio


### PR DESCRIPTION
## What was wrong?

The `async_service.asyncio.external_api` was not type hinted correctly and was lacking tests.

## How was it fixed?

Fixed the type hints as well as including typing tests to confirm these type hints are correct as well as expanding the test suite for this decorator.

#### Cute Animal Picture

![animals-santa-costumes-large-msg-132459460314](https://user-images.githubusercontent.com/824194/70821340-18692580-1d98-11ea-9a9b-8e9ea7b7322f.jpg)
