### PR TITLE
Implement trio external api decorator

### DIFF
--- a/tests-trio/test_trio_external_api.py
+++ b/tests-trio/test_trio_external_api.py
@@ -1,0 +1,77 @@
+import pytest
+import trio
+
+from async_service import Service, ServiceCancelled, background_trio_service
+from async_service.trio import external_api
+
+
+class ExternalAPIService(Service):
+    async def run(self):
+        await self.manager.wait_finished()
+
+    @external_api
+    async def get_7(self, wait_return=None, signal_event=None):
+        if signal_event is not None:
+            signal_event.set()
+        if wait_return is not None:
+            await wait_return.wait()
+        return 7
+
+
+@pytest.mark.trio
+async def test_trio_service_external_api_fails_before_start():
+    service = ExternalAPIService()
+
+    # should raise if the service has not yet been started.
+    with pytest.raises(ServiceCancelled):
+        await service.get_7()
+
+
+@pytest.mark.trio
+async def test_trio_service_external_api_works_while_running():
+    service = ExternalAPIService()
+
+    async with background_trio_service(service):
+        assert await service.get_7() == 7
+
+
+@pytest.mark.trio
+async def test_trio_service_external_api_raises_when_cancelled():
+    service = ExternalAPIService()
+
+    async with background_trio_service(service) as manager:
+        with pytest.raises(ServiceCancelled):
+            async with trio.open_nursery() as nursery:
+                # an event to ensure that we are indeed within the body of the
+                is_within_fn = trio.Event()
+                trigger_return = trio.Event()
+
+                nursery.start_soon(service.get_7, trigger_return, is_within_fn)
+
+                # ensure we're within the body of the task.
+                await is_within_fn.wait()
+
+                # now cancel the service and trigger the return of the function.
+                manager.cancel()
+
+                # exiting the context block here will cause the background task
+                # to complete and shold raise the exception
+
+        # A direct call should also fail.  This *should* be hitting the early
+        # return mechanism.
+        with pytest.raises(ServiceCancelled):
+            assert await service.get_7()
+
+
+@pytest.mark.trio
+async def test_trio_service_external_api_raises_when_finished():
+    service = ExternalAPIService()
+
+    async with background_trio_service(service) as manager:
+        pass
+
+    assert manager.is_finished
+    # A direct call should also fail.  This *should* be hitting the early
+    # return mechanism.
+    with pytest.raises(ServiceCancelled):
+        assert await service.get_7()


### PR DESCRIPTION
Fixes #17 

## What was wrong?

Need `external_trio_api` decorator

## How was it fixed?

created it.

#### Cute Animal Picture

![3172](https://user-images.githubusercontent.com/824194/70939582-c4637880-2005-11ea-9b39-725d7d36bc04.jpg)

