### PR TITLE
Ensure the InternalManagerAPI is public

### DIFF
--- a/async_service/abc.py
+++ b/async_service/abc.py
@@ -5,7 +5,7 @@ import trio_typing
 
 
 class ServiceAPI(ABC):
-    manager: "_InternalManagerAPI"
+    manager: "InternalManagerAPI"
 
     @abstractmethod
     async def run(self) -> None:
@@ -145,11 +145,11 @@ class ManagerAPI(ABC):
         ...
 
 
-class _InternalManagerAPI(ManagerAPI):
+class InternalManagerAPI(ManagerAPI):
     """
     Defines the API that the `Service.manager` property exposes.
 
-    The _InternalManagerAPI / ManagerAPI distinction is in place to ensure that
+    The InternalManagerAPI / ManagerAPI distinction is in place to ensure that
     external callers to a service do not try to use the task scheduling
     functionality as it is only designed to be used internally.
     """

--- a/async_service/base.py
+++ b/async_service/base.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Awaitable, Callable, List, Type
 
-from .abc import ManagerAPI, ServiceAPI, _InternalManagerAPI
+from .abc import InternalManagerAPI, ManagerAPI, ServiceAPI
 from .exceptions import LifecycleError
 from .typing import EXC_INFO
 
@@ -31,7 +31,7 @@ def as_service(service_fn: LogicFnType) -> Type[ServiceAPI]:
     return _Service
 
 
-class BaseManager(_InternalManagerAPI):
+class BaseManager(InternalManagerAPI):
     logger = logging.getLogger("async_service.Manager")
 
     _service: ServiceAPI

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,6 +14,15 @@ ManagerAPI
     :show-inheritance:
 
 
+InternalManagerAPI
+------------------
+
+.. autoclass:: async_service.abc.InternalManagerAPI
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 ServiceAPI
 ----------
 

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -150,7 +150,7 @@ Asynchrounous applications will typically need to run multiple things
 concurrently which implies running things in the *background*.
 
 This is done using the :attr:`~async_service.abc.ServiceAPI.manager`
-attribute which exposes the :meth:`~async_service.abc._InternalManagerAPI.run_task`
+attribute which exposes the :meth:`~async_service.abc.InternalManagerAPI.run_task`
 method.
 
 .. code-block:: python
@@ -176,7 +176,7 @@ Upon exiting, all errors that were encountered while running the service will
 be re-raised.
 
 For slighly nicer logging output you can provide a ``name`` as a keyword
-argument to `~async_service.abc._InternalManagerAPI.run_task` which will be
+argument to `~async_service.abc.InternalManagerAPI.run_task` which will be
 used in logging messages.
 
 
@@ -185,7 +185,7 @@ Daemon Tasks
 
 A *"Daemon"* tasks is one that is intended to run for the full lifecycle of the
 service.  This can be done by passing ``daemon=True`` into the call to
-:meth:`~async_service.abc._InternalManagerAPI.run_task`.
+:meth:`~async_service.abc.InternalManagerAPI.run_task`.
 
 .. code-block:: python
 
@@ -202,7 +202,7 @@ service.  This can be done by passing ``daemon=True`` into the call to
             self.manager.run_daemon_task(self.do_long_running_thing)
 
 
-Alternatively you can use :meth:`~async_service.abc._InternalManagerAPI.run_daemon_task`.
+Alternatively you can use :meth:`~async_service.abc.InternalManagerAPI.run_daemon_task`.
 
 A *"Daemon"* task which finishes before the service is stopping will trigger
 cancellation and result in the
@@ -230,13 +230,13 @@ want to run within a running service.
             child_manager = self.manager.run_child_service(ChildService())
 
 Child services are run using the
-:meth:`~async_service.abc._InternalManagerAPI.run_child_service` method which
+:meth:`~async_service.abc.InternalManagerAPI.run_child_service` method which
 returns the manager for the child service.
 
 There is also a
-:meth:`~async_service.abc._InternalManagerAPI.run_daemon_child_service`
+:meth:`~async_service.abc.InternalManagerAPI.run_daemon_child_service`
 method behaves the same as
-:meth:`~async_service.abc._InternalManagerAPI.run_daemon_task` in that if the
+:meth:`~async_service.abc.InternalManagerAPI.run_daemon_task` in that if the
 child service finishes before the parent service has finished, it will raise a
 :class:`~async_service.exceptions.DaemonTaskExit` exception.
 


### PR DESCRIPTION
## What was wrong?

The API that services have access to from within the service should be documented and public.

## How was it fixed?

Removed the `_` prefix.

#### Cute Animal Picture

![angry-kitty-in-christmas-hat](https://user-images.githubusercontent.com/824194/70952383-4dd57380-2023-11ea-9c30-2fa0e486f54c.jpg)

