### PR TITLE
Dissallow task running if the service is no longer running

### DIFF
--- a/async_service/asyncio_compat.py
+++ b/async_service/asyncio_compat.py
@@ -1,0 +1,9 @@
+import asyncio
+import sys
+
+if sys.version_info >= (3, 7):
+    # This API isn't available in 3.6
+    get_current_task = asyncio.current_task
+else:
+    # This API is deprecated in 3.7+
+    get_current_task = asyncio.Task.current_task

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -188,6 +188,10 @@ class TrioManager(BaseManager):
         daemon: bool = False,
         name: str = None,
     ) -> None:
+        if not self.is_running or self.is_cancelled:
+            raise LifecycleError(
+                "Tasks may not be scheduled if the service is not running"
+            )
         task_name = get_task_name(async_fn, name)
 
         self._task_nursery.start_soon(


### PR DESCRIPTION
## What was wrong?

Scheduling a task after the service is no longer running should be disallowed.

## How was it fixed?

Added a check to `run_task` to enforce this.

#### Cute Animal Picture

![animal-cat-christmas-costume-cute-Favim com-249668](https://user-images.githubusercontent.com/824194/70953191-c0dfe980-2025-11ea-976c-338ebf3da4ce.jpg)

