### PR TITLE
TrioManager now awaits for tasks to complete

### DIFF
--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -63,7 +63,7 @@ class AsyncioManager(BaseManager):
         """
         self.logger.debug("%s: _handle_cancelled waiting for cancellation", self)
         await self.wait_cancelled()
-        self.logger.debug("%s: _handle_cancelled triggering task cancellation", self)
+        self.logger.debug("%s: _handle_cancelled triggering task DAG cancellation", self)
 
         # TODO: need new comment here explaining the way we iterate in
         # dependency first order.

--- a/async_service/testing.py
+++ b/async_service/testing.py
@@ -1,0 +1,59 @@
+from async_service import Service
+
+
+async def _test_service_task_cancellation_dag_order(
+        event_class, sleep_fn, cancelled_class, background_service_fn, wait_events_fn):
+    dag = {
+        0: (1, 2, 3),
+        1: (),
+        2: (4, 5),
+        3: (),
+        4: (6, 7, 8, 9, 10),
+        5: (),
+        6: (),
+        7: (),
+        8: (11,),
+        9: (),
+        10: (),
+        11: (12,),
+        12: (13,),
+        13: (),
+    }
+    cancelled = []
+
+    class ServiceTest(Service):
+        def __init__(self):
+            self._task_events = {task_id: event_class() for task_id in dag.keys()}
+
+        async def _do_task(self, task_id):
+            children = dag[task_id]
+            for child_id in children:
+                self.manager.run_task(self._do_task, child_id)
+
+            # yield for a moment to give these time to start
+            await sleep_fn(0)
+            self._task_events[task_id].set()
+            self.manager.logger.info("Task %d started", task_id)
+            try:
+                await self.manager.wait_finished()
+            except cancelled_class:
+                self.manager.logger.info("Task %d cancelled", task_id)
+                cancelled.append(task_id)
+                raise
+
+        async def run(self):
+            await self._do_task(0)
+
+    service = ServiceTest()
+    async with background_service_fn(service) as manager:
+        await wait_events_fn(service._task_events.values())
+        manager.cancel()
+
+    assert len(cancelled) == len(dag)
+
+    seen = set()
+    for value in cancelled:
+        assert value not in seen
+        children = dag[value]
+        assert seen.issuperset(children)
+        seen.add(value)

--- a/async_service/testing.py
+++ b/async_service/testing.py
@@ -1,3 +1,5 @@
+from async_generator import asynccontextmanager
+
 from async_service import Service
 
 
@@ -57,3 +59,39 @@ async def _test_service_task_cancellation_dag_order(
         children = dag[value]
         assert seen.issuperset(children)
         seen.add(value)
+
+
+class Resource:
+    is_active = True
+
+
+class CheckParentAndChildTaskTerminationOrderService(Service):
+    cancelled_class = None
+
+    async def sleep(self, delay):
+        raise NotImplementedError()
+
+    async def run(self):
+        self.manager.run_task(self.setup_and_consume_res)
+        # Sleep more than 0 seconds to ensure all our tasks get a chance to run.
+        await self.sleep(0.1)
+        self.manager.cancel()
+
+    async def setup_and_consume_res(self):
+        async with self.get_resource() as res:
+            self.manager.run_task(self.consume_res, res)
+            await self.sleep(0)
+            await self.manager.wait_finished()
+
+    async def consume_res(self, res):
+        assert res.is_active
+        try:
+            await self.manager.wait_finished()
+        finally:
+            assert res.is_active
+
+    @asynccontextmanager
+    async def get_resource(self):
+        res = Resource()
+        yield res
+        res.active = False

--- a/async_service/testing.py
+++ b/async_service/testing.py
@@ -30,12 +30,12 @@ async def _test_service_task_cancellation_dag_order(
         async def _do_task(self, task_id):
             children = dag[task_id]
             for child_id in children:
-                self.manager.run_task(self._do_task, child_id)
+                self.manager.run_task(self._do_task, child_id, name=f'task-{child_id}')
 
             # yield for a moment to give these time to start
             await sleep_fn(0)
             self._task_events[task_id].set()
-            self.manager.logger.info("Task %d started", task_id)
+            self.manager.logger.debug("Task %d started", task_id)
             try:
                 await self.manager.wait_finished()
             except cancelled_class:

--- a/tests-asyncio/test_asyncio_based_service.py
+++ b/tests-asyncio/test_asyncio_based_service.py
@@ -10,6 +10,7 @@ from async_service import (
     as_service,
     background_asyncio_service,
 )
+from async_service.testing import CheckParentAndChildTaskTerminationOrderService
 
 
 class WaitCancelledService(Service):
@@ -412,3 +413,16 @@ async def test_asyncio_service_with_async_generator():
     async with background_asyncio_service(ServiceTest()) as manager:
         await is_within_agen.wait()
         manager.cancel()
+
+
+@pytest.mark.asyncio
+async def test_parent_task_terminates_after_child():
+    s = AsyncioCheckParentAndChildTaskTerminationOrderService()
+    await AsyncioManager.run_service(s)
+
+
+class AsyncioCheckParentAndChildTaskTerminationOrderService(
+        CheckParentAndChildTaskTerminationOrderService):
+
+    async def sleep(self, delay):
+        await asyncio.sleep(delay)

--- a/tests-asyncio/test_task_dag_cancellation_order.py
+++ b/tests-asyncio/test_task_dag_cancellation_order.py
@@ -2,60 +2,16 @@ import asyncio
 
 import pytest
 
-from async_service import Service, background_asyncio_service
+from async_service import background_asyncio_service
+from async_service.testing import _test_service_task_cancellation_dag_order
+
+
+async def wait_events(events):
+    await asyncio.gather(*(event.wait() for event in events))
 
 
 @pytest.mark.asyncio
 async def test_asyncio_service_task_cancellation_dag_order():
-    dag = {
-        0: (1, 2, 3),
-        1: (),
-        2: (4, 5),
-        3: (),
-        4: (6, 7, 8, 9, 10),
-        5: (),
-        6: (),
-        7: (),
-        8: (11,),
-        9: (),
-        10: (),
-        11: (12,),
-        12: (13,),
-        13: (),
-    }
-    cancelled = []
-
-    class ServiceTest(Service):
-        def __init__(self):
-            self._task_events = {task_id: asyncio.Event() for task_id in dag.keys()}
-
-        async def _do_task(self, task_id):
-            children = dag[task_id]
-            for child_id in children:
-                self.manager.run_task(self._do_task, child_id)
-
-            # yield for a moment to give these time to start
-            await asyncio.sleep(0)
-            self._task_events[task_id].set()
-            try:
-                await self.manager.wait_finished()
-            except asyncio.CancelledError:
-                cancelled.append(task_id)
-                raise
-
-        async def run(self):
-            await self._do_task(0)
-
-    service = ServiceTest()
-    async with background_asyncio_service(service) as manager:
-        await asyncio.gather(*(event.wait() for event in service._task_events.values()))
-        manager.cancel()
-
-    assert len(cancelled) == len(dag)
-
-    seen = set()
-    for value in cancelled:
-        assert value not in seen
-        children = dag[value]
-        assert seen.issuperset(children)
-        seen.add(value)
+    await _test_service_task_cancellation_dag_order(
+        asyncio.Event, asyncio.sleep, asyncio.CancelledError, background_asyncio_service,
+        wait_events)

--- a/tests-trio/test_task_dag_cancellation_order.py
+++ b/tests-trio/test_task_dag_cancellation_order.py
@@ -1,0 +1,19 @@
+import trio
+
+import pytest
+
+from async_service import background_trio_service
+from async_service.testing import _test_service_task_cancellation_dag_order
+
+
+async def wait_events(events):
+    async with trio.open_nursery() as nursery:
+        for event in events:
+            nursery.start_soon(event.wait)
+
+
+@pytest.mark.trio
+async def test_trio_service_task_cancellation_dag_order():
+    await _test_service_task_cancellation_dag_order(
+        trio.Event, trio.sleep, trio.Cancelled, background_trio_service,
+        wait_events)

--- a/tests-trio/test_trio_based_service.py
+++ b/tests-trio/test_trio_based_service.py
@@ -8,6 +8,7 @@ from async_service import (
     as_service,
     background_trio_service,
 )
+from async_service.testing import CheckParentAndChildTaskTerminationOrderService
 
 
 class WaitCancelledService(Service):
@@ -457,3 +458,16 @@ async def test_trio_service_with_async_generator():
     async with background_trio_service(ServiceTest()) as manager:
         await is_within_agen.wait()
         manager.cancel()
+
+
+@pytest.mark.trio
+async def test_parent_task_terminates_after_child():
+    s = TrioCheckParentAndChildTaskTerminationOrderService()
+    await TrioManager.run_service(s)
+
+
+class TrioCheckParentAndChildTaskTerminationOrderService(
+        CheckParentAndChildTaskTerminationOrderService):
+
+    async def sleep(self, delay):
+        await trio.sleep(delay)


### PR DESCRIPTION
Similarly to AsyncioManager, we keep track of the hierarchy of tasks 
created, but instead of cancelling them explicitly we let trio do that for
us and we simply wait for them to complete in the correct order

Note to self: this breaks trinity tests, need to investigate