### PR TITLE
Piper/ensure parent child termination rules

### DIFF
--- a/async_service/testing.py
+++ b/async_service/testing.py
@@ -1,0 +1,39 @@
+from async_generator import asynccontextmanager
+
+from async_service import Service
+
+
+class Resource:
+    is_active = True
+
+
+class CheckParentAndChildTaskTerminationOrderService(Service):
+    cancelled_class = None
+
+    async def sleep(self, delay):
+        raise NotImplementedError()
+
+    async def run(self):
+        self.manager.run_task(self.setup_and_consume_res)
+        # Sleep more than 0 seconds to ensure all our tasks get a chance to run.
+        await self.sleep(0.1)
+        self.manager.cancel()
+
+    async def setup_and_consume_res(self):
+        async with self.get_resource() as res:
+            self.manager.run_task(self.consume_res, res)
+            await self.sleep(0)
+            await self.manager.wait_finished()
+
+    async def consume_res(self, res):
+        assert res.is_active
+        try:
+            await self.manager.wait_finished()
+        finally:
+            assert res.is_active
+
+    @asynccontextmanager
+    async def get_resource(self):
+        res = Resource()
+        yield res
+        res.active = False

--- a/tests-asyncio/test_asyncio_based_service.py
+++ b/tests-asyncio/test_asyncio_based_service.py
@@ -10,6 +10,7 @@ from async_service import (
     as_service,
     background_asyncio_service,
 )
+from async_service.testing import CheckParentAndChildTaskTerminationOrderService
 
 
 class WaitCancelledService(Service):
@@ -412,3 +413,16 @@ async def test_asyncio_service_with_async_generator():
     async with background_asyncio_service(ServiceTest()) as manager:
         await is_within_agen.wait()
         manager.cancel()
+
+
+@pytest.mark.asyncio
+async def test_parent_task_terminates_after_child():
+    s = AsyncioCheckParentAndChildTaskTerminationOrderService()
+    await AsyncioManager.run_service(s)
+
+
+class AsyncioCheckParentAndChildTaskTerminationOrderService(
+        CheckParentAndChildTaskTerminationOrderService):
+
+    async def sleep(self, delay):
+        await asyncio.sleep(delay)

--- a/tests-trio/test_trio_based_service.py
+++ b/tests-trio/test_trio_based_service.py
@@ -8,6 +8,7 @@ from async_service import (
     as_service,
     background_trio_service,
 )
+from async_service.testing import CheckParentAndChildTaskTerminationOrderService
 
 
 class WaitCancelledService(Service):
@@ -457,3 +458,16 @@ async def test_trio_service_with_async_generator():
     async with background_trio_service(ServiceTest()) as manager:
         await is_within_agen.wait()
         manager.cancel()
+
+
+@pytest.mark.trio
+async def test_parent_task_terminates_after_child():
+    s = TrioCheckParentAndChildTaskTerminationOrderService()
+    await TrioManager.run_service(s)
+
+
+class TrioCheckParentAndChildTaskTerminationOrderService(
+        CheckParentAndChildTaskTerminationOrderService):
+
+    async def sleep(self, delay):
+        await trio.sleep(delay)


### PR DESCRIPTION
Demonstrates that current trio task fails at both DAG cancellation.