### PR TITLE
Improve DAG cancellation test and make it reusable

### DIFF
--- a/async_service/tools/_dag_test.py
+++ b/async_service/tools/_dag_test.py
@@ -1,0 +1,137 @@
+from abc import abstractmethod
+import asyncio
+import logging
+import random
+from typing import Any, Dict, Tuple, Type, Union
+
+import trio
+
+from async_service import Service
+
+DAG = Dict[int, Tuple[int, ...]]
+
+DEFAULT_DAG: DAG = {
+    0: (1, 2, 3),
+    1: (),
+    2: (4, 5),
+    3: (),
+    4: (6, 7, 8, 9, 10),
+    5: (),
+    6: (),
+    7: (),
+    8: (11,),
+    9: (),
+    10: (),
+    11: (12,),
+    12: (13,),
+    13: (),
+}
+
+
+class Resource:
+    is_active = None
+    was_checked = False
+
+    async def __aenter__(self) -> "Resource":
+        self.is_active = True
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        self.is_active = False
+
+
+class DAGServiceTest(Service):
+    """
+    This service is for testing whether the task DAG gets shutdown in the
+    correct order.
+    """
+
+    logger = logging.getLogger("async_service.testing.DAGServiceTest")
+
+    event_class: Union[Type[trio.Event], Type[asyncio.Event]]
+
+    @abstractmethod
+    async def yield_execution(self, count: int) -> None:
+        ...
+
+    @abstractmethod
+    async def ready_cancel(self) -> None:
+        ...
+
+    def __init__(self, dag: DAG = None):
+        if dag is None:
+            self._dag = DEFAULT_DAG
+        else:
+            self._dag = dag
+
+        # A set of tasks that signal that all of the dag child tasks are at a
+        # state in which they can be cancelled.
+        self._child_tasks_all_ready_events = {
+            task_id: self.event_class() for task_id in self._dag.keys()
+        }
+        self._task_resources = {task_id: Resource() for task_id in self._dag.keys()}
+
+        self.sanity_flag = False
+
+    async def _do_task(self, task_id: int, resource: Resource) -> None:
+        self.logger.info("task-%d: START", task_id)
+        assert not resource.is_active
+        assert not resource.was_checked
+        try:
+            async with resource:
+                assert resource.is_active
+                # run the children of this task
+                self.manager.run_task(self._do_child, task_id, resource)
+                await self.manager.wait_finished()
+        finally:
+            self.logger.info("task-%d: EXITING", task_id)
+            await self.yield_execution(random.randint(0, 100))
+            assert not resource.is_active
+            assert resource.was_checked
+            self.logger.info("task-%d: FINISH", task_id)
+
+    async def _do_child(self, task_id: int, resource: Resource) -> None:
+        self.logger.info("child--%d: START", task_id)
+        assert resource.is_active
+        assert not resource.was_checked
+
+        try:
+            self._run_children(task_id)
+            self._child_tasks_all_ready_events[task_id].set()
+            self.logger.info("child-%d: RUNNING", task_id)
+            await self.manager.wait_finished()
+        finally:
+            self.logger.info("child-%d: EXITING", task_id)
+            await self.yield_execution(random.randint(0, 100))
+            assert resource.is_active
+            resource.was_checked = True
+            self.logger.info("child-%d: FINISHED", task_id)
+
+    def _run_children(self, task_id: int) -> None:
+        child_tasks = self._dag[task_id]
+        for child_id in child_tasks:
+            resource = self._task_resources[child_id]
+            self.manager.run_task(self._do_task, child_id, resource)
+
+    async def run(self) -> None:
+        # pre-run sanity checks
+        assert all(
+            resource.is_active is None for resource in self._task_resources.values()
+        )
+        assert all(
+            resource.was_checked is False for resource in self._task_resources.values()
+        )
+        resource = self._task_resources[0]
+        try:
+            await self._do_task(0, resource)
+        finally:
+            # post-run sanity checks
+            for task_id, resource in self._task_resources.items():
+                if resource.is_active is not False:
+                    raise AssertionError(
+                        f"Resource for task-{task_id} was not `False`: {resource.is_active!r}"
+                    )
+            for task_id, resource in self._task_resources.items():
+                if resource.was_checked is not True:
+                    raise AssertionError(f"Resource for task-{task_id} was not checked")
+            self.sanity_flag = True

--- a/tests-asyncio/test_task_dag_cancellation_order.py
+++ b/tests-asyncio/test_task_dag_cancellation_order.py
@@ -2,60 +2,28 @@ import asyncio
 
 import pytest
 
-from async_service import Service, background_asyncio_service
+from async_service import background_asyncio_service
+from async_service.tools._dag_test import DAGServiceTest
+
+
+class AsyncioDAGServiceTest(DAGServiceTest):
+    event_class = asyncio.Event
+
+    async def yield_execution(self, count):
+        for _ in range(count):
+            await asyncio.sleep(0)
+
+    async def ready_cancel(self) -> None:
+        await asyncio.gather(
+            *(event.wait() for event in self._child_tasks_all_ready_events.values())
+        )
 
 
 @pytest.mark.asyncio
 async def test_asyncio_service_task_cancellation_dag_order():
-    dag = {
-        0: (1, 2, 3),
-        1: (),
-        2: (4, 5),
-        3: (),
-        4: (6, 7, 8, 9, 10),
-        5: (),
-        6: (),
-        7: (),
-        8: (11,),
-        9: (),
-        10: (),
-        11: (12,),
-        12: (13,),
-        13: (),
-    }
-    cancelled = []
-
-    class ServiceTest(Service):
-        def __init__(self):
-            self._task_events = {task_id: asyncio.Event() for task_id in dag.keys()}
-
-        async def _do_task(self, task_id):
-            children = dag[task_id]
-            for child_id in children:
-                self.manager.run_task(self._do_task, child_id)
-
-            # yield for a moment to give these time to start
-            await asyncio.sleep(0)
-            self._task_events[task_id].set()
-            try:
-                await self.manager.wait_finished()
-            except asyncio.CancelledError:
-                cancelled.append(task_id)
-                raise
-
-        async def run(self):
-            await self._do_task(0)
-
-    service = ServiceTest()
-    async with background_asyncio_service(service) as manager:
-        await asyncio.gather(*(event.wait() for event in service._task_events.values()))
-        manager.cancel()
-
-    assert len(cancelled) == len(dag)
-
-    seen = set()
-    for value in cancelled:
-        assert value not in seen
-        children = dag[value]
-        assert seen.issuperset(children)
-        seen.add(value)
+    # all of the assertions happen within the body of the service.
+    service = AsyncioDAGServiceTest()
+    assert service.sanity_flag is False
+    async with background_asyncio_service(service):
+        await service.ready_cancel()
+    assert service.sanity_flag is True


### PR DESCRIPTION
## What was wrong?

The existing test for DAG ordered cancellation wasn't re-usable and it didn't necessarily test the right thing.

## How was it fixed?

Re-worked the test such that it is reusable across both `asyncio` and `trio` and rework the way it does the test to more accurately test what we want it to test.

#### Cute Animal Picture

![santa-dog](https://user-images.githubusercontent.com/824194/71118126-b2641000-2194-11ea-80ba-41086c7bfb90.jpg)

