### PR TITLE
Trio dag based cancellation

### DIFF
--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -63,7 +63,7 @@ class AsyncioManager(BaseManager):
         background tasks.
         """
         self.logger.debug("%s: _handle_cancelled waiting for cancellation", self)
-        await self.wait_cancelled()
+        await self._cancelled.wait()
         self.logger.debug("%s: _handle_cancelled triggering task cancellation", self)
 
         # TODO: need new comment here explaining the way we iterate in
@@ -200,9 +200,6 @@ class AsyncioManager(BaseManager):
     #
     async def wait_started(self) -> None:
         await self._started.wait()
-
-    async def wait_cancelled(self) -> None:
-        await self._cancelled.wait()
 
     async def wait_stopping(self) -> None:
         await self._stopping.wait()

--- a/async_service/tools/_dag_test.py
+++ b/async_service/tools/_dag_test.py
@@ -81,7 +81,9 @@ class DAGServiceTest(Service):
             async with resource:
                 assert resource.is_active
                 # run the children of this task
-                self.manager.run_task(self._do_child, task_id, resource)
+                self.manager.run_task(
+                    self._do_child, task_id, resource, name=f"child-{task_id}"
+                )
                 await self.manager.wait_finished()
         finally:
             self.logger.info("task-%d: EXITING", task_id)
@@ -111,7 +113,9 @@ class DAGServiceTest(Service):
         child_tasks = self._dag[task_id]
         for child_id in child_tasks:
             resource = self._task_resources[child_id]
-            self.manager.run_task(self._do_task, child_id, resource)
+            self.manager.run_task(
+                self._do_task, child_id, resource, name=f"task-{task_id}"
+            )
 
     async def run(self) -> None:
         # pre-run sanity checks

--- a/async_service/tools/_dag_test.py
+++ b/async_service/tools/_dag_test.py
@@ -1,0 +1,137 @@
+from abc import abstractmethod
+import asyncio
+import logging
+import random
+from typing import Any, Dict, Tuple, Type, Union
+
+import trio
+
+from async_service import Service
+
+DAG = Dict[int, Tuple[int, ...]]
+
+DEFAULT_DAG: DAG = {
+    0: (1, 2, 3),
+    1: (),
+    2: (4, 5),
+    3: (),
+    4: (6, 7, 8, 9, 10),
+    5: (),
+    6: (),
+    7: (),
+    8: (11,),
+    9: (),
+    10: (),
+    11: (12,),
+    12: (13,),
+    13: (),
+}
+
+
+class Resource:
+    is_active = None
+    was_checked = False
+
+    async def __aenter__(self) -> "Resource":
+        self.is_active = True
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        self.is_active = False
+
+
+class DAGServiceTest(Service):
+    """
+    This service is for testing whether the task DAG gets shutdown in the
+    correct order.
+    """
+
+    logger = logging.getLogger("async_service.testing.DAGServiceTest")
+
+    event_class: Union[Type[trio.Event], Type[asyncio.Event]]
+
+    @abstractmethod
+    async def yield_execution(self, count: int) -> None:
+        ...
+
+    @abstractmethod
+    async def ready_cancel(self) -> None:
+        ...
+
+    def __init__(self, dag: DAG = None):
+        if dag is None:
+            self._dag = DEFAULT_DAG
+        else:
+            self._dag = dag
+
+        # A set of tasks that signal that all of the dag child tasks are at a
+        # state in which they can be cancelled.
+        self._child_tasks_all_ready_events = {
+            task_id: self.event_class() for task_id in self._dag.keys()
+        }
+        self._task_resources = {task_id: Resource() for task_id in self._dag.keys()}
+
+        self.sanity_flag = False
+
+    async def _do_task(self, task_id: int, resource: Resource) -> None:
+        self.logger.info("task-%d: START", task_id)
+        assert not resource.is_active
+        assert not resource.was_checked
+        try:
+            async with resource:
+                assert resource.is_active
+                # run the children of this task
+                self.manager.run_task(self._do_child, task_id, resource)
+                await self.manager.wait_finished()
+        finally:
+            self.logger.info("task-%d: EXITING", task_id)
+            await self.yield_execution(random.randint(0, 100))
+            assert not resource.is_active
+            assert resource.was_checked
+            self.logger.info("task-%d: FINISH", task_id)
+
+    async def _do_child(self, task_id: int, resource: Resource) -> None:
+        self.logger.info("child--%d: START", task_id)
+        assert resource.is_active
+        assert not resource.was_checked
+
+        try:
+            self._run_children(task_id)
+            self._child_tasks_all_ready_events[task_id].set()
+            self.logger.info("child-%d: RUNNING", task_id)
+            await self.manager.wait_finished()
+        finally:
+            self.logger.info("child-%d: EXITING", task_id)
+            await self.yield_execution(random.randint(0, 100))
+            assert resource.is_active
+            resource.was_checked = True
+            self.logger.info("child-%d: FINISHED", task_id)
+
+    def _run_children(self, task_id: int) -> None:
+        child_tasks = self._dag[task_id]
+        for child_id in child_tasks:
+            resource = self._task_resources[child_id]
+            self.manager.run_task(self._do_task, child_id, resource)
+
+    async def run(self) -> None:
+        # pre-run sanity checks
+        assert all(
+            resource.is_active is None for resource in self._task_resources.values()
+        )
+        assert all(
+            resource.was_checked is False for resource in self._task_resources.values()
+        )
+        resource = self._task_resources[0]
+        try:
+            await self._do_task(0, resource)
+        finally:
+            # post-run sanity checks
+            for task_id, resource in self._task_resources.items():
+                if resource.is_active is not False:
+                    raise AssertionError(
+                        f"Resource for task-{task_id} was not `False`: {resource.is_active!r}"
+                    )
+            for task_id, resource in self._task_resources.items():
+                if resource.was_checked is not True:
+                    raise AssertionError(f"Resource for task-{task_id} was not checked")
+            self.sanity_flag = True

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Coroutine,
     Dict,
+    List,
     Optional,
     Tuple,
     TypeVar,
@@ -17,7 +18,7 @@ from async_generator import asynccontextmanager
 import trio
 import trio_typing
 
-from ._utils import get_task_name
+from ._utils import get_task_name, iter_dag
 from .abc import ManagerAPI, ServiceAPI
 from .base import BaseManager
 from .exceptions import DaemonTaskExit, LifecycleError, ServiceCancelled
@@ -25,32 +26,64 @@ from .typing import EXC_INFO
 
 
 class TrioManager(BaseManager):
+    _is_cancelled = False
+
     # A nursery for sub tasks and services.  This nursery is cancelled if the
     # service is cancelled but allowed to exit normally if the service exits.
     _task_nursery: trio_typing.Nursery
+
+    _service_task_dag: Dict[trio.hazmat.Task, List[trio.hazmat.Task]]
+    _task_done_events: Dict[trio.hazmat.Task, trio.Event]
+    _task_cancel_scopes: Dict[trio.hazmat.Task, trio.CancelScope]
 
     def __init__(self, service: ServiceAPI) -> None:
         super().__init__(service)
 
         # events
         self._started = trio.Event()
+        self._cancelled = trio.Event()
         self._stopping = trio.Event()
         self._finished = trio.Event()
 
         # locks
         self._run_lock = trio.Lock()
 
+        # DAG tracking
+        self._service_task_dag = {}
+        self._task_cancel_scopes = {}
+        self._task_done_events = {}
+
     #
     # System Tasks
     #
+    async def _handle_cancelled(self) -> None:
+        # Here we iterate over the task DAG such that we cancel the most deeply
+        # nested tasks first ensuring that each has finished completely before
+        # we move onto cancelling the parent tasks.
+        self.logger.debug("%s: _handle_cancelled waiting for cancellation", self)
+        await self._cancelled.wait()
+        self.logger.debug("%s: _handle_cancelled triggering task cancellation", self)
+
+        for task in iter_dag(self._service_task_dag):
+            cancel_scope = self._task_cancel_scopes[task]
+            done = self._task_done_events[task]
+            cancel_scope.cancel()
+            await done.wait()
+
+        # This finaly cancellation of the task nursery's cancel scope ensures
+        # that nothing is left behind and that the service will reliably exit.
+        self._task_nursery.cancel_scope.cancel()
+
     async def _handle_run(self) -> None:
         """
         Run and monitor the actual :meth:`ServiceAPI.run` method.
 
         In the event that it throws an exception the service will be cancelled.
         """
+        done, cancel_scope = self._track_current_task()
         try:
-            await self._service.run()
+            with cancel_scope:
+                await self._service.run()
         except Exception as err:
             self.logger.debug(
                 "%s: _handle_run got error, storing exception and setting cancelled: %s",
@@ -68,6 +101,8 @@ class TrioManager(BaseManager):
             self.logger.debug(
                 "%s: _handle_run exited cleanly, waiting for full stop...", self
             )
+        finally:
+            done.set()
 
     @classmethod
     async def run_service(cls, service: ServiceAPI) -> None:
@@ -84,22 +119,27 @@ class TrioManager(BaseManager):
 
         try:
             async with self._run_lock:
-                try:
-                    async with trio.open_nursery() as task_nursery:
-                        self._task_nursery = task_nursery
+                async with trio.open_nursery() as system_nursery:
+                    system_nursery.start_soon(self._handle_cancelled)
 
-                        task_nursery.start_soon(self._handle_run)
+                    try:
+                        async with trio.open_nursery() as task_nursery:
+                            self._task_nursery = task_nursery
 
-                        self._started.set()
+                            task_nursery.start_soon(self._handle_run)
 
-                        # ***BLOCKING HERE***
-                        # The code flow will block here until the background tasks have
-                        # completed or cancellation occurs.
-                except Exception:
-                    # Exceptions from any tasks spawned by our service will be caught by trio
-                    # and raised here, so we store them to report together with any others we
-                    # have already captured.
-                    self._errors.append(cast(EXC_INFO, sys.exc_info()))
+                            self._started.set()
+
+                            # ***BLOCKING HERE***
+                            # The code flow will block here until the background tasks have
+                            # completed or cancellation occurs.
+                    except Exception:
+                        # Exceptions from any tasks spawned by our service will be caught by trio
+                        # and raised here, so we store them to report together with any others we
+                        # have already captured.
+                        self._errors.append(cast(EXC_INFO, sys.exc_info()))
+                    finally:
+                        system_nursery.cancel_scope.cancel()
 
         finally:
             # We need this inside a finally because a trio.Cancelled exception may be raised
@@ -128,10 +168,7 @@ class TrioManager(BaseManager):
 
     @property
     def is_cancelled(self) -> bool:
-        if not hasattr(self, "_task_nursery"):
-            return False
-        cancel_scope = self._task_nursery.cancel_scope
-        return cancel_scope.cancel_called or cancel_scope.cancelled_caught
+        return self._cancelled.is_set()
 
     @property
     def is_stopping(self) -> bool:
@@ -147,7 +184,10 @@ class TrioManager(BaseManager):
     def cancel(self) -> None:
         if not self.is_started:
             raise LifecycleError("Cannot cancel as service which was never started.")
-        self._task_nursery.cancel_scope.cancel()
+        elif not self.is_running:
+            return
+        else:
+            self._cancelled.set()
 
     #
     # Wait API
@@ -161,16 +201,44 @@ class TrioManager(BaseManager):
     async def wait_finished(self) -> None:
         await self._finished.wait()
 
+    def _track_current_task(
+        self, parent: trio.hazmat.Task = None
+    ) -> Tuple[trio.Event, trio.CancelScope]:
+        current_task = trio.hazmat.current_task()
+        if parent is not None:
+            # This covers the case for the *root* task which doesn't have a
+            # parent.
+            self._service_task_dag[parent].append(current_task)
+
+        # We use an event to manually track when the child task is "done".
+        # This is because trio has no API for awaiting completion of a task.
+        done = trio.Event()
+        self._task_done_events[current_task] = done
+
+        # Each task gets its own `CancelScope` which is how we can manually
+        # control cancellation order of the task DAG
+        cancel_scope = trio.CancelScope()
+        self._task_cancel_scopes[current_task] = cancel_scope
+
+        # This data structure is setup so that child tasks can *inject*
+        # themselves in as dependencies.
+        self._service_task_dag[current_task] = []
+
+        return done, cancel_scope
+
     async def _run_and_manage_task(
         self,
         async_fn: Callable[..., Awaitable[Any]],
         *args: Any,
         daemon: bool,
         name: str,
+        parent: trio.hazmat.Task,
     ) -> None:
         self.logger.debug("running task '%s[daemon=%s]'", name, daemon)
+        done, cancel_scope = self._track_current_task(parent)
         try:
-            await async_fn(*args)
+            with cancel_scope:
+                await async_fn(*args)
         except Exception as err:
             self.logger.debug(
                 "task '%s[daemon=%s]' exited with error: %s",
@@ -191,6 +259,8 @@ class TrioManager(BaseManager):
                 )
                 self.cancel()
                 raise DaemonTaskExit(f"Daemon task {name} exited")
+        finally:
+            done.set()
 
     def run_task(
         self,
@@ -204,9 +274,15 @@ class TrioManager(BaseManager):
                 "Tasks may not be scheduled if the service is not running"
             )
         task_name = get_task_name(async_fn, name)
+        current_task = trio.hazmat.current_task()
 
         self._task_nursery.start_soon(
-            functools.partial(self._run_and_manage_task, daemon=daemon, name=task_name),
+            functools.partial(
+                self._run_and_manage_task,
+                daemon=daemon,
+                name=task_name,
+                parent=current_task,
+            ),
             async_fn,
             *args,
             name=task_name,

--- a/tests-asyncio/test_asyncio_based_service.py
+++ b/tests-asyncio/test_asyncio_based_service.py
@@ -15,7 +15,7 @@ from async_service import (
 
 class WaitCancelledService(Service):
     async def run(self) -> None:
-        await self.manager.wait_cancelled()
+        await self.manager.wait_finished()
 
 
 async def do_service_lifecycle_check(
@@ -263,7 +263,7 @@ async def test_asyncio_service_manager_run_task():
             task_event.set()
 
         manager.run_task(task_fn)
-        await manager.wait_cancelled()
+        await manager.wait_finished()
 
     async with background_asyncio_service(RunTaskService()):
         await asyncio.wait_for(task_event.wait(), timeout=0.1)

--- a/tests-asyncio/test_asyncio_dag_cancellation.py
+++ b/tests-asyncio/test_asyncio_dag_cancellation.py
@@ -23,7 +23,7 @@ class AsyncioDAGServiceTest(DAGServiceTest):
 async def test_asyncio_service_task_cancellation_dag_order():
     # all of the assertions happen within the body of the service.
     service = AsyncioDAGServiceTest()
-    assert service.sanity_flag is False
+    assert service.all_checks_passed is False
     async with background_asyncio_service(service):
         await service.ready_cancel()
-    assert service.sanity_flag is True
+    assert service.all_checks_passed is True

--- a/tests-asyncio/test_task_dag_cancellation_order.py
+++ b/tests-asyncio/test_task_dag_cancellation_order.py
@@ -2,60 +2,28 @@ import asyncio
 
 import pytest
 
-from async_service import Service, background_asyncio_service
+from async_service import background_asyncio_service
+from async_service.tools._dag_test import DAGServiceTest
+
+
+class AsyncioDAGServiceTest(DAGServiceTest):
+    event_class = asyncio.Event
+
+    async def yield_execution(self, count):
+        for _ in range(count):
+            await asyncio.sleep(0)
+
+    async def ready_cancel(self) -> None:
+        await asyncio.gather(
+            *(event.wait() for event in self._child_tasks_all_ready_events.values())
+        )
 
 
 @pytest.mark.asyncio
 async def test_asyncio_service_task_cancellation_dag_order():
-    dag = {
-        0: (1, 2, 3),
-        1: (),
-        2: (4, 5),
-        3: (),
-        4: (6, 7, 8, 9, 10),
-        5: (),
-        6: (),
-        7: (),
-        8: (11,),
-        9: (),
-        10: (),
-        11: (12,),
-        12: (13,),
-        13: (),
-    }
-    cancelled = []
-
-    class ServiceTest(Service):
-        def __init__(self):
-            self._task_events = {task_id: asyncio.Event() for task_id in dag.keys()}
-
-        async def _do_task(self, task_id):
-            children = dag[task_id]
-            for child_id in children:
-                self.manager.run_task(self._do_task, child_id)
-
-            # yield for a moment to give these time to start
-            await asyncio.sleep(0)
-            self._task_events[task_id].set()
-            try:
-                await self.manager.wait_finished()
-            except asyncio.CancelledError:
-                cancelled.append(task_id)
-                raise
-
-        async def run(self):
-            await self._do_task(0)
-
-    service = ServiceTest()
-    async with background_asyncio_service(service) as manager:
-        await asyncio.gather(*(event.wait() for event in service._task_events.values()))
-        manager.cancel()
-
-    assert len(cancelled) == len(dag)
-
-    seen = set()
-    for value in cancelled:
-        assert value not in seen
-        children = dag[value]
-        assert seen.issuperset(children)
-        seen.add(value)
+    # all of the assertions happen within the body of the service.
+    service = AsyncioDAGServiceTest()
+    assert service.sanity_flag is False
+    async with background_asyncio_service(service):
+        await service.ready_cancel()
+    assert service.sanity_flag is True

--- a/tests-trio/test_trio_dag_cancellation.py
+++ b/tests-trio/test_trio_dag_cancellation.py
@@ -22,7 +22,7 @@ class TrioDAGServiceTest(DAGServiceTest):
 async def test_trio_service_task_cancellation_dag_order():
     # all of the assertions happen within the body of the service.
     service = TrioDAGServiceTest()
-    assert service.sanity_flag is False
+    assert service.all_checks_passed is False
     async with background_trio_service(service):
         await service.ready_cancel()
-    assert service.sanity_flag is True
+    assert service.all_checks_passed is True

--- a/tests-trio/test_trio_dag_cancellation.py
+++ b/tests-trio/test_trio_dag_cancellation.py
@@ -1,0 +1,28 @@
+import pytest
+import trio
+
+from async_service import background_trio_service
+from async_service.tools._dag_test import DAGServiceTest
+
+
+class TrioDAGServiceTest(DAGServiceTest):
+    event_class = trio.Event
+
+    async def yield_execution(self, count):
+        with trio.CancelScope(shield=True):
+            for _ in range(count):
+                await trio.hazmat.checkpoint()
+
+    async def ready_cancel(self) -> None:
+        for event in self._child_tasks_all_ready_events.values():
+            await event.wait()
+
+
+@pytest.mark.trio
+async def test_trio_service_task_cancellation_dag_order():
+    # all of the assertions happen within the body of the service.
+    service = TrioDAGServiceTest()
+    assert service.sanity_flag is False
+    async with background_trio_service(service):
+        await service.ready_cancel()
+    assert service.sanity_flag is True


### PR DESCRIPTION
Builds on #29

## What was wrong?

The `TrioManager` didn't follow the task DAG cancellation order.

## How was it fixed?

Updated the implementation to correctly follow the DAG based task cancellation.

#### Cute Animal Picture

![christmas-cat-dressed-up](https://user-images.githubusercontent.com/824194/71122749-864d8c80-219e-11ea-9018-1304d8770719.jpg)

