### PR TITLE
Allow for external API calls to schedule tasks

### DIFF
--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -265,6 +265,8 @@ class AsyncioManager(BaseManager):
         self._service_task_dag[task] = []
         if parent_task in self._service_task_dag:
             self._service_task_dag[parent_task].append(task)
+        else:
+            self.logger.debug("New root task %s[daemon=%s] added to DAG", task, daemon)
 
     def run_child_service(
         self, service: ServiceAPI, daemon: bool = False, name: str = None


### PR DESCRIPTION
fixes #33

## What was wrong?

See #33

## How was it fixed?

Now when the parent task is not locally tracked we treat the new task being scheduled as a "root" node in the task DAG

#### Cute Animal Picture


![365166b81326ee48435214df4e785ec3](https://user-images.githubusercontent.com/824194/71133771-0254ce00-21b9-11ea-9638-93febb828655.jpg)
