### PR TITLE
Allow external API calls to schedule tasks under trio manager

### DIFF
--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -261,7 +261,9 @@ class AsyncioManager(BaseManager):
         if parent_task in self._service_task_dag:
             self._service_task_dag[parent_task].append(task)
         else:
-            self.logger.debug("New root task %s[daemon=%s] added to DAG", task, daemon)
+            self.logger.debug(
+                "New root task %s[daemon=%s] added to DAG", task_name, daemon
+            )
 
     def run_child_service(
         self, service: ServiceAPI, daemon: bool = False, name: str = None


### PR DESCRIPTION
## What was wrong?

The `TrioManager` would complain if an external API call ends up scheduling a task.

## How was it fixed?

Adjusted the code to allow for external API calls to schedule tasks which become new root nodes in the task DAG

#### Cute Animal Picture

![christmas-hat-kitty](https://user-images.githubusercontent.com/824194/71203580-78117600-225b-11ea-88ef-b0e95cd6fcf2.jpg)
