### PR TITLE
Allow scheduling anytime `Manager.is_running` is true (even if cancelled)

### DIFF
--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -64,9 +64,16 @@ class AsyncioManager(BaseManager):
         await self._cancelled.wait()
         self.logger.debug("%s: _handle_cancelled triggering task cancellation", self)
 
-        # TODO: need new comment here explaining the way we iterate in
-        # dependency first order.
-        for task in iter_dag(self._service_task_dag):
+        # Here we iterate over the task DAG such that we cancel the most deeply
+        # nested tasks first ensuring that each has finished completely before
+        # we move onto cancelling the parent tasks.
+        #
+        # We have to make a copy of the task dag because it is possible that
+        # there is a task which has just been scheduled. In this case the new
+        # task will end up being cancelled as part of it's parent task's cancel
+        # scope, **or** if it was scheduled by an external API call it will be
+        # cancelled as part of the global task nursery's cancellation.
+        for task in iter_dag(self._service_task_dag.copy()):
             if not task.done():
                 task.cancel()
 
@@ -245,7 +252,7 @@ class AsyncioManager(BaseManager):
         daemon: bool = False,
         name: str = None,
     ) -> None:
-        if not self.is_running or self.is_cancelled:
+        if not self.is_running:
             raise LifecycleError(
                 "Tasks may not be scheduled if the service is not running"
             )

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -279,7 +279,17 @@ class TrioManager(BaseManager):
             raise LifecycleError(
                 "Tasks may not be scheduled if the service is not running"
             )
+
         task_name = get_task_name(async_fn, name)
+        if self.is_running and self.is_cancelled:
+            self.logger.debug(
+                "Service is in the process of being cancelled. Not running task "
+                "%s[daemon=%s]",
+                task_name,
+                daemon,
+            )
+            return
+
         current_task = trio.hazmat.current_task()
 
         self._task_nursery.start_soon(

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -55,14 +55,20 @@ class TrioManager(BaseManager):
     # System Tasks
     #
     async def _handle_cancelled(self) -> None:
-        # Here we iterate over the task DAG such that we cancel the most deeply
-        # nested tasks first ensuring that each has finished completely before
-        # we move onto cancelling the parent tasks.
         self.logger.debug("%s: _handle_cancelled waiting for cancellation", self)
         await self._cancelled.wait()
         self.logger.debug("%s: _handle_cancelled triggering task cancellation", self)
 
-        for task in iter_dag(self._service_task_dag):
+        # Here we iterate over the task DAG such that we cancel the most deeply
+        # nested tasks first ensuring that each has finished completely before
+        # we move onto cancelling the parent tasks.
+        #
+        # We have to make a copy of the task dag because it is possible that
+        # there is a task which has just been scheduled. In this case the new
+        # task will end up being cancelled as part of it's parent task's cancel
+        # scope, **or** if it was scheduled by an external API call it will be
+        # cancelled as part of the global task nursery's cancellation.
+        for task in iter_dag(self._service_task_dag.copy()):
             cancel_scope = self._task_cancel_scopes[task]
             done = self._task_done_events[task]
             cancel_scope.cancel()
@@ -269,7 +275,7 @@ class TrioManager(BaseManager):
         daemon: bool = False,
         name: str = None,
     ) -> None:
-        if not self.is_running or self.is_cancelled:
+        if not self.is_running:
             raise LifecycleError(
                 "Tasks may not be scheduled if the service is not running"
             )


### PR DESCRIPTION
## What was wrong?

It turns out that we cannot forbid task scheduled in cancelled services.  This is because both the `cancel()` API and the `run_task()` API are synchronous and we cannot reliably keep from running into a `self.run_task` shortly after cancellation has been triggered but before it has been delivered to a task.

## How was it fixed?

Only restrict to `is_running`

#### Cute Animal Picture

![santa-hat-kitty](https://user-images.githubusercontent.com/824194/71208563-7d27f280-2266-11ea-93e8-bd8f599f1ea5.jpg)
