### PR TITLE
Add a __str__ implementation for managers

### DIFF
--- a/async_service/base.py
+++ b/async_service/base.py
@@ -49,6 +49,19 @@ class BaseManager(InternalManagerAPI):
         # errors
         self._errors = []
 
+    def __str__(self) -> str:
+        return (
+            "<Manager  "
+            f"service={self._service}  "
+            f"started={self.is_started}  "
+            f"running={self.is_running}  "
+            f"cancelled={self.is_cancelled}  "
+            f"stopping={self.is_stopping}  "
+            f"finished={self.is_finished}  "
+            f"did_error={self.did_error}"
+            ">"
+        )
+
     #
     # Event API mirror
     #


### PR DESCRIPTION
## What was wrong?

The manager instances don't have `__str__` implementations which makes them less useful in things like logging messages.

## How was it fixed?

Added a `__str__` method which exposes all of the metadata about the status of the manager.

```
<Manager  service="whatever Service.__str__ returns" started=True  running=False  cancelled=True  stopping=True  finished=False  did_error=False> stopping
```

#### Cute Animal Picture

![d6163ee9bf2baf6bc5ee509279b5d2cd--christmas-elf-christmas-animals](https://user-images.githubusercontent.com/824194/71208320-ff63e700-2265-11ea-96c2-45bf337aac93.jpg)
