### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -314,7 +314,7 @@ the following patterns.  However, special care and consideration should be
 taken as the following patterns can result in the application hanging when we
 try to shut it down.
 
-The basic idea is to use a ``try/finally`` expression in we main
+The basic idea is to use a ``try/finally`` expression in our main
 ``Service.run()`` method.  Since services track and shutdown their tasks using
 a DAG, the code in the ``finally`` block is guaranteed to run after everything
 else has stopped.


### PR DESCRIPTION
## What was wrong?

Grammar typo

## How was it fixed?

Replaced `we` with `our`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://image.shutterstock.com/image-photo/funny-guinea-pig-glasses-reading-260nw-424834873.jpg)
