### PR TITLE
Add get_manager() API to Service and make manager attribute private

### DIFF
--- a/async_service/abc.py
+++ b/async_service/abc.py
@@ -5,7 +5,17 @@ import trio_typing
 
 
 class ServiceAPI(ABC):
-    manager: "InternalManagerAPI"
+    _manager: "InternalManagerAPI"
+
+    @abstractmethod
+    def get_manager(self) -> "ManagerAPI":
+        """
+        External retrieval of the manager for this service.
+
+        Will raise a :class:`~async_service.exceptions.LifecycleError` if the
+        service does not yet have a `manager` assigned to it.
+        """
+        ...
 
     @abstractmethod
     async def run(self) -> None:

--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -333,7 +333,7 @@ def external_api(func: TFunc) -> TFunc:
                 f"Cannot access external API {func}.  Service has not been run."
             )
 
-        manager = self.manager
+        manager = self.get_manager()
 
         if not manager.is_running:
             raise ServiceCancelled(

--- a/async_service/base.py
+++ b/async_service/base.py
@@ -15,8 +15,6 @@ class Service(ServiceAPI):
         proper type hints will not have access to this property since it isn't
         part of that API, while still allowing all subclasses of the
         :class:`async_service.base.Service` to access this property directly.
-
-        This allows for
         """
         return self._manager
 
@@ -59,7 +57,7 @@ class BaseManager(InternalManagerAPI):
     _errors: List[EXC_INFO]
 
     def __init__(self, service: ServiceAPI) -> None:
-        if hasattr(service, "manager"):
+        if hasattr(service, "_manager"):
             raise LifecycleError("Service already has a manager.")
         else:
             service._manager = self

--- a/async_service/base.py
+++ b/async_service/base.py
@@ -7,7 +7,27 @@ from .typing import EXC_INFO
 
 
 class Service(ServiceAPI):
-    pass
+    @property
+    def manager(self) -> "InternalManagerAPI":
+        """
+        Expose the manager as a property here intead of
+        :class:`async_service.abc.ServiceAPI` to ensure that anyone using
+        proper type hints will not have access to this property since it isn't
+        part of that API, while still allowing all subclasses of the
+        :class:`async_service.base.Service` to access this property directly.
+
+        This allows for
+        """
+        return self._manager
+
+    def get_manager(self) -> ManagerAPI:
+        try:
+            return self._manager
+        except AttributeError:
+            raise LifecycleError(
+                "Service does not have a manager assigned to it.  Are you sure "
+                "it is running?"
+            )
 
 
 LogicFnType = Callable[..., Awaitable[Any]]
@@ -42,7 +62,7 @@ class BaseManager(InternalManagerAPI):
         if hasattr(service, "manager"):
             raise LifecycleError("Service already has a manager.")
         else:
-            service.manager = self
+            service._manager = self
 
         self._service = service
 

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -324,9 +324,9 @@ async def _wait_stopping_or_finished(
     api_func: Callable[..., Any],
     channel: trio.abc.SendChannel[_ChannelPayload],
 ) -> None:
-    manager = service.manager
+    manager = service.get_manager()
 
-    if service.manager.is_stopping or service.manager.is_finished:
+    if manager.is_stopping or manager.is_finished:
         await channel.send(
             (
                 None,
@@ -339,7 +339,7 @@ async def _wait_stopping_or_finished(
         )
         return
 
-    await service.manager.wait_stopping()
+    await manager.wait_stopping()
     await channel.send(
         (
             None,
@@ -380,7 +380,7 @@ def external_api(func: TFunc) -> TFunc:
                 f"Cannot access external API {func}.  Service has not been run."
             )
 
-        manager = self.manager
+        manager = self.get_manager()
 
         if not manager.is_running:
             raise ServiceCancelled(

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -149,7 +149,7 @@ Tasks
 Asynchrounous applications will typically need to run multiple things
 concurrently which implies running things in the *background*.
 
-This is done using the :attr:`~async_service.abc.ServiceAPI.manager`
+This is done using the :attr:`~async_service.base.Service.manager`
 attribute which exposes the :meth:`~async_service.abc.InternalManagerAPI.run_task`
 method.
 
@@ -164,7 +164,7 @@ method.
 
         async def run(self):
             for url in URLS_TO_FETCH:
-                self.manager.run_task(fetch_url, url)
+                self._manager.run_task(fetch_url, url)
 
 The example above shows a service that concurrently fetches multiple URLS
 concurrently.  These *tasks* will be scheduled and run in the background.  The

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -164,7 +164,7 @@ method.
 
         async def run(self):
             for url in URLS_TO_FETCH:
-                self._manager.run_task(fetch_url, url)
+                self.manager.run_task(fetch_url, url)
 
 The example above shows a service that concurrently fetches multiple URLS
 concurrently.  These *tasks* will be scheduled and run in the background.  The

--- a/tests-trio/test_trio_based_service.py
+++ b/tests-trio/test_trio_based_service.py
@@ -13,7 +13,7 @@ from async_service import (
 
 class WaitCancelledService(Service):
     async def run(self) -> None:
-        await self._manager.wait_finished()
+        await self.manager.wait_finished()
 
 
 async def do_service_lifecycle_check(
@@ -235,7 +235,7 @@ async def test_multierror_in_run():
     class ServiceTest(Service):
         async def run(self):
             in_daemon = trio.Event()
-            self._manager.run_daemon_task(self.daemon_task_fn, in_daemon)
+            self.manager.run_daemon_task(self.daemon_task_fn, in_daemon)
             trigger_error.set()
             await in_daemon.wait()
             raise RuntimeError("Exception inside Service.run()")

--- a/tests-trio/test_trio_based_service.py
+++ b/tests-trio/test_trio_based_service.py
@@ -13,7 +13,7 @@ from async_service import (
 
 class WaitCancelledService(Service):
     async def run(self) -> None:
-        await self.manager.wait_finished()
+        await self._manager.wait_finished()
 
 
 async def do_service_lifecycle_check(
@@ -235,7 +235,7 @@ async def test_multierror_in_run():
     class ServiceTest(Service):
         async def run(self):
             in_daemon = trio.Event()
-            self.manager.run_daemon_task(self.daemon_task_fn, in_daemon)
+            self._manager.run_daemon_task(self.daemon_task_fn, in_daemon)
             trigger_error.set()
             await in_daemon.wait()
             raise RuntimeError("Exception inside Service.run()")
@@ -265,7 +265,7 @@ async def test_trio_service_background_service_context_manager():
     async with background_trio_service(service) as manager:
         # ensure the manager property is set.
         assert hasattr(service, "manager")
-        assert service.manager is manager
+        assert service.get_manager() is manager
 
         assert manager.is_started is True
         assert manager.is_running is True

--- a/tests-trio/test_trio_external_api.py
+++ b/tests-trio/test_trio_external_api.py
@@ -7,7 +7,7 @@ from async_service.trio import external_api
 
 class ExternalAPIService(Service):
     async def run(self):
-        await self.manager.wait_finished()
+        await self._manager.wait_finished()
 
     @external_api
     async def get_7(self, wait_return=None, signal_event=None):
@@ -83,11 +83,11 @@ async def test_trio_external_api_call_that_schedules_task():
 
     class MyService(Service):
         async def run(self):
-            await self.manager.wait_finished()
+            await self._manager.wait_finished()
 
         @external_api
         async def do_scheduling(self):
-            self.manager.run_task(self.set_done)
+            self._manager.run_task(self.set_done)
 
         async def set_done(self):
             done.set()

--- a/tests-trio/test_trio_external_api.py
+++ b/tests-trio/test_trio_external_api.py
@@ -7,7 +7,7 @@ from async_service.trio import external_api
 
 class ExternalAPIService(Service):
     async def run(self):
-        await self._manager.wait_finished()
+        await self.manager.wait_finished()
 
     @external_api
     async def get_7(self, wait_return=None, signal_event=None):
@@ -83,11 +83,11 @@ async def test_trio_external_api_call_that_schedules_task():
 
     class MyService(Service):
         async def run(self):
-            await self._manager.wait_finished()
+            await self.manager.wait_finished()
 
         @external_api
         async def do_scheduling(self):
-            self._manager.run_task(self.set_done)
+            self.manager.run_task(self.set_done)
 
         async def set_done(self):
             done.set()


### PR DESCRIPTION
## What was wrong?

While converting trinity to use this library it became apparent that there should be an API on the `ServiceAPI` which allows retrieval of the `ManagerAPI` for a running service.  We want this to expose a `ManagerAPI` instance as opposed to the `InternalManagerAPI` which is what is currently exposed through the property.

## How was it fixed?

There is a new `ServiceAPI.get_manager()` method which returns a `ManagerAPI` instance or raises a `LifecycleError` if the manager has not yet been set.

The actual manager instance is now stored  at `ServiceAPI._manager` which appropriately makes it a private attribute.  The `async_service.base.Service` class now exposes a computed property to still allow `self.manager` access from within any subclass of `Service`.

#### Cute Animal Picture

![christmas-dog](https://user-images.githubusercontent.com/824194/72005118-0e590c00-320a-11ea-85f5-464f6aabe757.jpg)

