### PR TITLE
task stats

### DIFF
--- a/async_service/abc.py
+++ b/async_service/abc.py
@@ -3,6 +3,8 @@ from typing import Any, Awaitable, Callable
 
 import trio_typing
 
+from .stats import Stats
+
 
 class ServiceAPI(ABC):
     _manager: "InternalManagerAPI"
@@ -151,6 +153,14 @@ class ManagerAPI(ABC):
     async def run(self) -> None:
         """
         Run a service
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def stats(self) -> Stats:
+        """
+        Return a stats object with details about the service.
         """
         ...
 

--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -22,6 +22,7 @@ from .abc import ManagerAPI, ServiceAPI
 from .asyncio_compat import get_current_task
 from .base import BaseManager
 from .exceptions import DaemonTaskExit, LifecycleError, ServiceCancelled
+from .stats import Stats, TaskStats
 from .typing import EXC_INFO
 
 
@@ -289,6 +290,16 @@ class AsyncioManager(BaseManager):
         task_name = get_task_name(service, name)
         self.run_task(child_manager.run, daemon=daemon, name=task_name)
         return child_manager
+
+    @property
+    def stats(self) -> Stats:
+        total_count = max(0, len(self._service_task_dag) - 1)
+        finished_count = min(
+            total_count, len([task for task in self._service_task_dag if task.done()])
+        )
+        return Stats(
+            tasks=TaskStats(total_count=total_count, finished_count=finished_count)
+        )
 
 
 @asynccontextmanager

--- a/async_service/stats.py
+++ b/async_service/stats.py
@@ -1,0 +1,14 @@
+from typing import NamedTuple
+
+
+class TaskStats(NamedTuple):
+    total_count: int
+    finished_count: int
+
+    @property
+    def pending_count(self) -> int:
+        return self.total_count - self.finished_count
+
+
+class Stats(NamedTuple):
+    tasks: TaskStats

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -22,6 +22,7 @@ from ._utils import get_task_name, iter_dag
 from .abc import ManagerAPI, ServiceAPI
 from .base import BaseManager
 from .exceptions import DaemonTaskExit, LifecycleError, ServiceCancelled
+from .stats import Stats, TaskStats
 from .typing import EXC_INFO
 
 
@@ -311,6 +312,17 @@ class TrioManager(BaseManager):
         task_name = get_task_name(service, name)
         self.run_task(child_manager.run, daemon=daemon, name=task_name)
         return child_manager
+
+    @property
+    def stats(self) -> Stats:
+        total_count = max(0, len(self._service_task_dag) - 1)
+        finished_count = min(
+            total_count,
+            len([event for event in self._task_done_events.values() if event.is_set()]),
+        )
+        return Stats(
+            tasks=TaskStats(total_count=total_count, finished_count=finished_count)
+        )
 
 
 TFunc = TypeVar("TFunc", bound=Callable[..., Coroutine[Any, Any, Any]])

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -315,7 +315,17 @@ class TrioManager(BaseManager):
 
     @property
     def stats(self) -> Stats:
+        # The `max` call here ensures that if this is called prior to the
+        # `Service.run` method starting we don't return `-1`
         total_count = max(0, len(self._service_task_dag) - 1)
+
+        # Since we track `Service.run` as a task, the `min` call here ensures
+        # that when the service is fully done that we don't represent the
+        # `Service.run` method in this count.
+        #
+        # TODO: There is currenty a case where the service is still running but
+        # the `Service.run` method has finished where this will show an
+        # inflated number of finished tasks.
         finished_count = min(
             total_count,
             len([event for event in self._task_done_events.values() if event.is_set()]),

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -305,6 +305,7 @@ decorator.
 When a method decorated with :func:`~async_service.external_asyncio_api` fails
 it raises an :class:`async_service.exceptions.ServiceCancelled` exception.
 
+
 Cleanup logic
 -------------
 
@@ -378,3 +379,21 @@ It is relatively trivial to implement a reusable pattern for doing cleanup.
 
         async def on_finally(self) -> None:
             pass
+
+
+Stats
+-----
+
+The :class:`~async_service.abc.ManagerAPI` exposes a
+:meth:`~async_service.abc.ManagerAPI.stats` method which returns a
+:class:`~async_service.stats.Stats` object with basic stats about the running
+service.
+
+.. code-block:: python
+
+    async with background_asyncio_service(MyService) as manager:
+        stats = manager.stats
+
+        print(f"Total running tasks: {stats.total_count}")
+        print(f"Finished tasks: {stats.finished_count}")
+        print(f"Pending tasks: {stats.pending_count}")

--- a/tests-asyncio/test_asyncio_manager_stats.py
+++ b/tests-asyncio/test_asyncio_manager_stats.py
@@ -1,0 +1,48 @@
+import asyncio
+
+import pytest
+
+from async_service import Service, background_asyncio_service
+
+
+@pytest.mark.asyncio
+async def test_asyncio_manager_stats():
+    ready = asyncio.Event()
+
+    class StatsTest(Service):
+        async def run(self):
+            # 2 that run forever
+            self.manager.run_task(asyncio.sleep, 100)
+            self.manager.run_task(asyncio.sleep, 100)
+
+            # 3 that complete
+            self.manager.run_task(asyncio.sleep, 0)
+            self.manager.run_task(asyncio.sleep, 0)
+
+            # 1 that spawns some children
+            self.manager.run_task(self.run_with_children, 5)
+
+            await self.manager.wait_finished()
+
+        async def run_with_children(self, num_children):
+            for _ in range(num_children):
+                self.manager.run_task(asyncio.sleep, 100)
+            ready.set()
+            await self.manager.wait_finished()
+
+    async with background_asyncio_service(StatsTest()) as manager:
+        await asyncio.wait_for(ready.wait(), timeout=1)
+
+        # we need to yield to the event loop a few times to allow the various
+        # tasks to schedule themselves and get running.
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+        assert manager.stats.tasks.total_count == 10
+        assert manager.stats.tasks.finished_count == 2
+        assert manager.stats.tasks.pending_count == 8
+
+    # now check after exiting
+    assert manager.stats.tasks.total_count == 10
+    assert manager.stats.tasks.finished_count == 10
+    assert manager.stats.tasks.pending_count == 0

--- a/tests-asyncio/test_asyncio_manager_stats.py
+++ b/tests-asyncio/test_asyncio_manager_stats.py
@@ -15,7 +15,7 @@ async def test_asyncio_manager_stats():
             self.manager.run_task(asyncio.sleep, 100)
             self.manager.run_task(asyncio.sleep, 100)
 
-            # 3 that complete
+            # 2 that complete
             self.manager.run_task(asyncio.sleep, 0)
             self.manager.run_task(asyncio.sleep, 0)
 
@@ -45,4 +45,34 @@ async def test_asyncio_manager_stats():
     # now check after exiting
     assert manager.stats.tasks.total_count == 10
     assert manager.stats.tasks.finished_count == 10
+    assert manager.stats.tasks.pending_count == 0
+
+
+# This test accounts for a current deficiency in the stats tracking that will
+# count the `Service.run` method in the statistics.
+@pytest.mark.xfail
+@pytest.mark.asyncio
+async def test_asyncio_manager_stats_does_not_count_main_run_method():
+    ready = asyncio.Event()
+
+    class StatsTest(Service):
+        async def run(self):
+            self.manager.run_task(asyncio.sleep_forever)
+            ready.set()
+
+    async with background_asyncio_service(StatsTest()) as manager:
+        await asyncio.wait_for(ready.wait(), timout=1)
+
+        # we need to yield to the event loop a few times to allow the various
+        # tasks to schedule themselves and get running.
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+        assert manager.stats.tasks.total_count == 1
+        assert manager.stats.tasks.finished_count == 0  # this currently fails
+        assert manager.stats.tasks.pending_count == 1  # this currently fails
+
+    # now check after exiting
+    assert manager.stats.tasks.total_count == 1
+    assert manager.stats.tasks.finished_count == 1
     assert manager.stats.tasks.pending_count == 0

--- a/tests-trio/test_trio_manager_stats.py
+++ b/tests-trio/test_trio_manager_stats.py
@@ -14,7 +14,7 @@ async def test_trio_manager_stats():
             self.manager.run_task(trio.sleep_forever)
             self.manager.run_task(trio.sleep_forever)
 
-            # 3 that complete
+            # 2 that complete
             self.manager.run_task(trio.hazmat.checkpoint)
             self.manager.run_task(trio.hazmat.checkpoint)
 
@@ -45,4 +45,35 @@ async def test_trio_manager_stats():
     # now check after exiting
     assert manager.stats.tasks.total_count == 10
     assert manager.stats.tasks.finished_count == 10
+    assert manager.stats.tasks.pending_count == 0
+
+
+# This test accounts for a current deficiency in the stats tracking that will
+# count the `Service.run` method in the statistics.
+@pytest.mark.xfail
+@pytest.mark.trio
+async def test_trio_manager_stats_does_not_count_main_run_method():
+    ready = trio.Event()
+
+    class StatsTest(Service):
+        async def run(self):
+            self.manager.run_task(trio.sleep_forever)
+            ready.set()
+
+    async with background_trio_service(StatsTest()) as manager:
+        with trio.fail_after(1):
+            await ready.wait()
+
+        # we need to yield to the event loop a few times to allow the various
+        # tasks to schedule themselves and get running.
+        for _ in range(10):
+            await trio.hazmat.checkpoint()
+
+        assert manager.stats.tasks.total_count == 1
+        assert manager.stats.tasks.finished_count == 0  # this currently fails
+        assert manager.stats.tasks.pending_count == 1  # this currently fails
+
+    # now check after exiting
+    assert manager.stats.tasks.total_count == 1
+    assert manager.stats.tasks.finished_count == 1
     assert manager.stats.tasks.pending_count == 0

--- a/tests-trio/test_trio_manager_stats.py
+++ b/tests-trio/test_trio_manager_stats.py
@@ -1,0 +1,48 @@
+import pytest
+import trio
+
+from async_service import Service, background_trio_service
+
+
+@pytest.mark.trio
+async def test_trio_manager_stats():
+    ready = trio.Event()
+
+    class StatsTest(Service):
+        async def run(self):
+            # 2 that run forever
+            self.manager.run_task(trio.sleep_forever)
+            self.manager.run_task(trio.sleep_forever)
+
+            # 3 that complete
+            self.manager.run_task(trio.hazmat.checkpoint)
+            self.manager.run_task(trio.hazmat.checkpoint)
+
+            # 1 that spawns some children
+            self.manager.run_task(self.run_with_children, 5)
+
+            await self.manager.wait_finished()
+
+        async def run_with_children(self, num_children):
+            for _ in range(num_children):
+                self.manager.run_task(trio.sleep_forever)
+            ready.set()
+            await self.manager.wait_finished()
+
+    async with background_trio_service(StatsTest()) as manager:
+        with trio.fail_after(1):
+            await ready.wait()
+
+        # we need to yield to the event loop a few times to allow the various
+        # tasks to schedule themselves and get running.
+        for _ in range(50):
+            await trio.hazmat.checkpoint()
+
+        assert manager.stats.tasks.total_count == 10
+        assert manager.stats.tasks.finished_count == 2
+        assert manager.stats.tasks.pending_count == 8
+
+    # now check after exiting
+    assert manager.stats.tasks.total_count == 10
+    assert manager.stats.tasks.finished_count == 10
+    assert manager.stats.tasks.pending_count == 0


### PR DESCRIPTION
## What was wrong?

Need an standard API for inspecting information about the tasks of a running service.

## How was it fixed?

Added a `ManagerAPI.stats` computed property that returns data about the running stats.

#### Cute Animal Picture

![en293901](https://user-images.githubusercontent.com/824194/72278568-84d28100-35f1-11ea-860c-3e000e344687.jpg)

