### PR TITLE
Cleanup task running logic

### DIFF
--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -74,7 +74,7 @@ class AsyncioManager(BaseManager):
         # task will end up being cancelled as part of it's parent task's cancel
         # scope, **or** if it was scheduled by an external API call it will be
         # cancelled as part of the global task nursery's cancellation.
-        for task in iter_dag(self._service_task_dag.copy()):
+        for task in iter_dag(self._service_task_dag):
             if not task.done():
                 task.cancel()
 
@@ -171,7 +171,7 @@ class AsyncioManager(BaseManager):
             done, pending = await asyncio.wait(
                 tuple(self._service_task_dag.keys()), return_when=asyncio.ALL_COMPLETED
             )
-            if all(task.done() for task in self._service_task_dag.keys()):
+            if all(task.done() for task in self._service_task_dag):
                 break
 
     #


### PR DESCRIPTION
Builds on #47

## What was wrong?

There were a few things about how tasks are run and managed that could be cleaned up due to library refactors.

## How was it fixed?

- `TrioManager` no longer uses a special wrapper for the `Service.run` method.  Now it uses the same logic for task running.
- We no longer need to make a copy of the task dag because the business logic no longer allows for the DAG to change during shutdown.

#### Cute Animal Picture

![91905-600-1446706672funny-cats-dogs-stuck-furniture-26](https://user-images.githubusercontent.com/824194/72457522-05c18200-3784-11ea-858a-9f62f5872740.jpg)
