### PR TITLE
Fix unbounded memory growth due to task tracking

### DIFF
--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -74,7 +74,7 @@ class AsyncioManager(BaseManager):
         # task will end up being cancelled as part of it's parent task's cancel
         # scope, **or** if it was scheduled by an external API call it will be
         # cancelled as part of the global task nursery's cancellation.
-        for task in iter_dag(self._service_task_dag.copy()):
+        for task in iter_dag(self._service_task_dag):
             if not task.done():
                 task.cancel()
 
@@ -171,7 +171,7 @@ class AsyncioManager(BaseManager):
             done, pending = await asyncio.wait(
                 tuple(self._service_task_dag.keys()), return_when=asyncio.ALL_COMPLETED
             )
-            if all(task.done() for task in self._service_task_dag.keys()):
+            if all(task.done() for task in self._service_task_dag):
                 break
 
     #

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -8,8 +8,8 @@ from typing import (
     Coroutine,
     Dict,
     Hashable,
-    List,
     Optional,
+    Set,
     Tuple,
     TypeVar,
     cast,
@@ -24,7 +24,6 @@ from ._utils import get_task_name, iter_dag
 from .abc import ManagerAPI, ServiceAPI
 from .base import BaseManager
 from .exceptions import DaemonTaskExit, LifecycleError, ServiceCancelled
-from .stats import Stats, TaskStats
 from .typing import EXC_INFO
 
 
@@ -91,7 +90,7 @@ class TrioManager(BaseManager):
     # service is cancelled but allowed to exit normally if the service exits.
     _task_nursery: trio_typing.Nursery
 
-    _service_task_dag: Dict[_Task, List[_Task]]
+    _service_task_dag: Dict[_Task, Set[_Task]]
 
     def __init__(self, service: ServiceAPI) -> None:
         super().__init__(service)
@@ -120,12 +119,12 @@ class TrioManager(BaseManager):
         # nested tasks first ensuring that each has finished completely before
         # we move onto cancelling the parent tasks.
         #
-        # We have to make a copy of the task dag because it is possible that
-        # there is a task which has just been scheduled. In this case the new
-        # task will end up being cancelled as part of its parent task's cancel
-        # scope, **or** if it was scheduled by an external API call it will be
-        # cancelled as part of the global task nursery's cancellation.
-        for task in iter_dag(self._service_task_dag):
+        # The `_service_task_dag` changes size as each task completes itself
+        # and removes itself from the dag.  For this reason we compute the
+        # cancellation order up front and then iterate over it so that we
+        # ensure we have a reference to all of the tasks in the DAG.
+        tasks_to_cancel = tuple(iter_dag(self._service_task_dag))
+        for task in tasks_to_cancel:
             task.cancel_scope.cancel()
             await task.done.wait()
 
@@ -266,8 +265,28 @@ class TrioManager(BaseManager):
                         )
                         self.cancel()
                         raise DaemonTaskExit(f"Daemon task {name} exited")
+                    while True:
+                        children_still_running = tuple(
+                            child_task
+                            for child_task in self._service_task_dag[task]
+                            if not child_task.done.is_set()
+                        )
+                        # If there are still child tasks that have not finished
+                        # wait for them.  Otherwise, this task can be
+                        # considered fully done and we can clean it up.
+                        if children_still_running:
+                            for child_task in children_still_running:
+                                await child_task.done.wait()
+                        else:
+                            break
         finally:
+            # mark the task as being done and then remove it from the dag and
+            # any set of dependencies that it may be part of.
             task.done.set()
+            self._service_task_dag.pop(task)
+            for dependencies in self._service_task_dag.values():
+                dependencies.discard(task)
+            self._done_task_count += 1
 
     def _get_parent_task(self, trio_task: trio.hazmat.Task) -> Optional[_Task]:
         """
@@ -320,9 +339,10 @@ class TrioManager(BaseManager):
             self.logger.debug("New root task %s added to DAG", task)
         else:
             self.logger.debug("New child task %s -> %s added to DAG", task.parent, task)
-            self._service_task_dag[task.parent].append(task)
+            self._service_task_dag[task.parent].add(task)
 
-        self._service_task_dag[task] = []
+        self._service_task_dag[task] = set()
+        self._total_task_count += 1
 
         self._task_nursery.start_soon(
             functools.partial(
@@ -340,27 +360,6 @@ class TrioManager(BaseManager):
         task_name = get_task_name(service, name)
         self.run_task(child_manager.run, daemon=daemon, name=task_name)
         return child_manager
-
-    @property
-    def stats(self) -> Stats:
-        # The `max` call here ensures that if this is called prior to the
-        # `Service.run` method starting we don't return `-1`
-        total_count = max(0, len(self._service_task_dag) - 1)
-
-        # Since we track `Service.run` as a task, the `min` call here ensures
-        # that when the service is fully done that we don't represent the
-        # `Service.run` method in this count.
-        #
-        # TODO: There is currenty a case where the service is still running but
-        # the `Service.run` method has finished where this will show an
-        # inflated number of finished tasks.
-        finished_count = min(
-            total_count,
-            len([task for task in self._service_task_dag if task.done.is_set()]),
-        )
-        return Stats(
-            tasks=TaskStats(total_count=total_count, finished_count=finished_count)
-        )
 
 
 TFunc = TypeVar("TFunc", bound=Callable[..., Coroutine[Any, Any, Any]])

--- a/tests-asyncio/test_asyncio_manager_stats.py
+++ b/tests-asyncio/test_asyncio_manager_stats.py
@@ -22,13 +22,10 @@ async def test_asyncio_manager_stats():
             # 1 that spawns some children
             self.manager.run_task(self.run_with_children, 5)
 
-            await self.manager.wait_finished()
-
         async def run_with_children(self, num_children):
             for _ in range(num_children):
                 self.manager.run_task(asyncio.sleep, 100)
             ready.set()
-            await self.manager.wait_finished()
 
     async with background_asyncio_service(StatsTest()) as manager:
         await asyncio.wait_for(ready.wait(), timeout=1)
@@ -42,6 +39,10 @@ async def test_asyncio_manager_stats():
         assert manager.stats.tasks.finished_count == 2
         assert manager.stats.tasks.pending_count == 8
 
+        # This is a simple test to ensure that finished tasks are removed from
+        # tracking to prevent unbounded memory growth.
+        assert len(manager._service_task_dag) == 9
+
     # now check after exiting
     assert manager.stats.tasks.total_count == 10
     assert manager.stats.tasks.finished_count == 10
@@ -50,18 +51,17 @@ async def test_asyncio_manager_stats():
 
 # This test accounts for a current deficiency in the stats tracking that will
 # count the `Service.run` method in the statistics.
-@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_asyncio_manager_stats_does_not_count_main_run_method():
     ready = asyncio.Event()
 
     class StatsTest(Service):
         async def run(self):
-            self.manager.run_task(asyncio.sleep_forever)
+            self.manager.run_task(asyncio.sleep, 100)
             ready.set()
 
     async with background_asyncio_service(StatsTest()) as manager:
-        await asyncio.wait_for(ready.wait(), timout=1)
+        await asyncio.wait_for(ready.wait(), timeout=1)
 
         # we need to yield to the event loop a few times to allow the various
         # tasks to schedule themselves and get running.
@@ -69,8 +69,8 @@ async def test_asyncio_manager_stats_does_not_count_main_run_method():
             await asyncio.sleep(0)
 
         assert manager.stats.tasks.total_count == 1
-        assert manager.stats.tasks.finished_count == 0  # this currently fails
-        assert manager.stats.tasks.pending_count == 1  # this currently fails
+        assert manager.stats.tasks.finished_count == 0
+        assert manager.stats.tasks.pending_count == 1
 
     # now check after exiting
     assert manager.stats.tasks.total_count == 1


### PR DESCRIPTION
builds on #48

fixes #43 

## What was wrong?

The mechanism for tracking the task DAG didn't cleanup finished tasks which allowed for unbounded memory growth over time.

## How was it fixed?

Now as each task finishes, they wait for all of their children to also be finished and then remove themselves from DAG tracking.

#### Cute Animal Picture

![dog_chair_lawn](https://user-images.githubusercontent.com/824194/72460975-2b9e5500-378b-11ea-834f-dc34829415b6.jpg)
