### PR TITLE
Fix incorrect daemon task exit during shutdown

### DIFF
--- a/async_service/base.py
+++ b/async_service/base.py
@@ -297,7 +297,13 @@ class BaseManager(InternalManagerAPI):
         self.logger.debug("%s: task %s running", self, task)
 
         try:
-            await task.run()
+            try:
+                await task.run()
+            except DaemonTaskExit:
+                if self.is_cancelled:
+                    pass
+                else:
+                    raise
         except asyncio.CancelledError:
             raise
         except Exception as err:


### PR DESCRIPTION
fixes #54

## What was wrong?

There was a race condition that would happen during shutdown when running a daemon child service which caused the child service to get incorrectly reported as a `DaemonTaskExit`.

## How was it fixed?

Only report as a `DaemonTaskExit` if the service is not cancelled.

#### Cute Animal Picture

![Animals-Stuck-in-Plastic-Garden-Chairs-1](https://user-images.githubusercontent.com/824194/73691746-2cdae780-4690-11ea-9136-41c4091ab9c2.jpg)

