### PR TITLE
Cleanup external API

### DIFF
--- a/async_service/__init__.py
+++ b/async_service/__init__.py
@@ -5,8 +5,12 @@ from .asyncio import (  # noqa: F401
     external_api as external_asyncio_api,
 )
 from .base import Service, as_service  # noqa: F401
-from .exceptions import DaemonTaskExit, LifecycleError, ServiceCancelled  # noqa: F401
-from .trio import TrioManager, background_trio_service  # noqa: F401
+from .exceptions import DaemonTaskExit, LifecycleError  # noqa: F401
+from .trio import (  # noqa: F401
+    TrioManager,
+    background_trio_service,
+    external_api as external_trio_api,
+)
 
 run_asyncio_service = AsyncioManager.run_service
 run_trio_service = TrioManager.run_service

--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -20,7 +20,7 @@ from ._utils import get_task_name
 from .abc import ManagerAPI, ServiceAPI, TaskAPI
 from .asyncio_compat import get_current_task
 from .base import BaseChildServiceTask, BaseFunctionTask, BaseManager
-from .exceptions import DaemonTaskExit, LifecycleError, ServiceCancelled
+from .exceptions import DaemonTaskExit, LifecycleError
 from .typing import EXC_INFO
 
 
@@ -353,14 +353,14 @@ def external_api(func: TFunc) -> TFunc:
     @functools.wraps(func)
     async def inner(self: ServiceAPI, *args: Any, **kwargs: Any) -> Any:
         if not hasattr(self, "manager"):
-            raise ServiceCancelled(
+            raise LifecycleError(
                 f"Cannot access external API {func}.  Service has not been run."
             )
 
         manager = self.get_manager()
 
         if not manager.is_running:
-            raise ServiceCancelled(
+            raise LifecycleError(
                 f"Cannot access external API {func}.  Service {self} is not running: "
             )
 
@@ -376,7 +376,7 @@ def external_api(func: TFunc) -> TFunc:
             if func_task.done():
                 return await func_task
             elif service_finished_task.done():
-                raise ServiceCancelled(
+                raise LifecycleError(
                     f"Cannot access external API {func}.  Service {self} is not running: "
                 )
             else:

--- a/async_service/exceptions.py
+++ b/async_service/exceptions.py
@@ -20,11 +20,3 @@ class DaemonTaskExit(ServiceException):
     """
 
     pass
-
-
-class ServiceCancelled(ServiceException):
-    """
-    Raised by external service APIs when a service is cancelled.
-    """
-
-    pass

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -21,7 +21,7 @@ import trio_typing
 from ._utils import get_task_name
 from .abc import ManagerAPI, ServiceAPI, TaskAPI
 from .base import BaseChildServiceTask, BaseFunctionTask, BaseManager
-from .exceptions import DaemonTaskExit, LifecycleError, ServiceCancelled
+from .exceptions import DaemonTaskExit, LifecycleError
 from .typing import EXC_INFO, AsyncFn
 
 
@@ -316,7 +316,7 @@ async def _wait_finished(
         await channel.send(
             (
                 None,
-                ServiceCancelled(
+                LifecycleError(
                     f"Cannot access external API {api_func}.  Service {service} is not running: "
                 ),
             )
@@ -327,7 +327,7 @@ async def _wait_finished(
     await channel.send(
         (
             None,
-            ServiceCancelled(
+            LifecycleError(
                 f"Cannot access external API {api_func}.  Service {service} is not running: "
             ),
         )
@@ -358,14 +358,14 @@ def external_api(func: TFunc) -> TFunc:
     @functools.wraps(func)
     async def inner(self: ServiceAPI, *args: Any, **kwargs: Any) -> Any:
         if not hasattr(self, "manager"):
-            raise ServiceCancelled(
+            raise LifecycleError(
                 f"Cannot access external API {func}.  Service {self} has not been run."
             )
 
         manager = self.get_manager()
 
         if not manager.is_running:
-            raise ServiceCancelled(
+            raise LifecycleError(
                 f"Cannot access external API {func}.  Service {self} is not running: "
             )
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -90,6 +90,10 @@ background_trio_service
 
 .. autofunction:: async_service.asyncio.background_asyncio_service
 
+external_api
+--------------------------
+
+.. autofunction:: async_service.trio.external_api
 
 Exceptions
 ~~~~~~~~~~
@@ -106,15 +110,6 @@ LifecycleError
 --------------
 
 .. autoclass:: async_service.exceptions.LifecycleError
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-ServiceCancelled
-----------------
-
-.. autoclass:: async_service.exceptions.ServiceCancelled
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -262,8 +262,8 @@ Sometimes we may want to expose an API from a
 should only work if the service is running, and calls should fail or be
 terminated if the service is cancelled or finishes.
 
-This can be done with the :func:`~async_service.asyncio.external_api`
-decorator.
+This can be done with the :func:`~async_service.external_asyncio_api` and
+:func:`~async_service.external_trio_api` decorators.
 
 .. code-block:: python
 
@@ -295,7 +295,7 @@ decorator.
 
 
 When a method decorated with :func:`~async_service.external_asyncio_api` fails
-it raises an :class:`async_service.exceptions.ServiceCancelled` exception.
+it raises an :class:`async_service.exceptions.LifecycleError` exception.
 
 
 Cleanup logic

--- a/tests-asyncio/test_asyncio_external_api.py
+++ b/tests-asyncio/test_asyncio_external_api.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from async_service import Service, ServiceCancelled, background_asyncio_service
+from async_service import LifecycleError, Service, background_asyncio_service
 from async_service.asyncio import external_api
 
 
@@ -24,7 +24,7 @@ async def test_asyncio_service_external_api_fails_before_start():
     service = ExternalAPIService()
 
     # should raise if the service has not yet been started.
-    with pytest.raises(ServiceCancelled):
+    with pytest.raises(LifecycleError):
         await service.get_7()
 
 
@@ -76,12 +76,12 @@ async def test_asyncio_service_external_api_raises_when_cancelled():
         # Since the task is in the middle of executing it wn't be done and thus
         # this should fail.  This should be hitting the `asyncio.wait(...)`
         # mechanism.
-        with pytest.raises(ServiceCancelled):
+        with pytest.raises(LifecycleError):
             assert await task == 7
 
         # A direct call should also fail.  This *should* be hitting the early
         # return mechanism.
-        with pytest.raises(ServiceCancelled):
+        with pytest.raises(LifecycleError):
             assert await service.get_7()
 
 
@@ -95,7 +95,7 @@ async def test_asyncio_service_external_api_raises_when_finished():
     assert manager.is_finished
     # A direct call should also fail.  This *should* be hitting the early
     # return mechanism.
-    with pytest.raises(ServiceCancelled):
+    with pytest.raises(LifecycleError):
         assert await service.get_7()
 
 

--- a/tests-trio/test_trio_external_api.py
+++ b/tests-trio/test_trio_external_api.py
@@ -1,7 +1,7 @@
 import pytest
 import trio
 
-from async_service import Service, ServiceCancelled, background_trio_service
+from async_service import LifecycleError, Service, background_trio_service
 from async_service.trio import external_api
 
 
@@ -23,7 +23,7 @@ async def test_trio_service_external_api_fails_before_start():
     service = ExternalAPIService()
 
     # should raise if the service has not yet been started.
-    with pytest.raises(ServiceCancelled):
+    with pytest.raises(LifecycleError):
         await service.get_7()
 
 
@@ -40,7 +40,7 @@ async def test_trio_service_external_api_raises_when_cancelled():
     service = ExternalAPIService()
 
     async with background_trio_service(service) as manager:
-        with pytest.raises(ServiceCancelled):
+        with pytest.raises(LifecycleError):
             async with trio.open_nursery() as nursery:
                 # an event to ensure that we are indeed within the body of the
                 is_within_fn = trio.Event()
@@ -59,7 +59,7 @@ async def test_trio_service_external_api_raises_when_cancelled():
 
         # A direct call should also fail.  This *should* be hitting the early
         # return mechanism.
-        with pytest.raises(ServiceCancelled):
+        with pytest.raises(LifecycleError):
             assert await service.get_7()
 
 
@@ -73,7 +73,7 @@ async def test_trio_service_external_api_raises_when_finished():
     assert manager.is_finished
     # A direct call should also fail.  This *should* be hitting the early
     # return mechanism.
-    with pytest.raises(ServiceCancelled):
+    with pytest.raises(LifecycleError):
         assert await service.get_7()
 
 


### PR DESCRIPTION
fixes #56 

## What was wrong?

The exception class that was used by the `external_api` decorators was called `ServiceCancelled` even though it can error in cases outside of the service being cancelled (like not yet started, or already finished).

## How was it fixed?

Changed to use the existing `LifecycleError` for the exception class

#### Cute Animal Picture

![848fc0fd80ba551e0dffad63f7b59ad6](https://user-images.githubusercontent.com/824194/73692913-817f6200-4692-11ea-9cf6-63c196ae70f5.jpg)

