### PR TITLE
Add flags= prefix to Service.__str__ implementation

### DIFF
--- a/async_service/base.py
+++ b/async_service/base.py
@@ -215,7 +215,7 @@ class BaseManager(InternalManagerAPI):
                 "E" if self.did_error else "e",
             )
         )
-        return f"<Manager[{self._service}] {status_flags}>"
+        return f"<Manager[{self._service}] flags={status_flags}>"
 
     #
     # Event API mirror


### PR DESCRIPTION
fixes #55 

## What was wrong?

See #55 

## How was it fixed?

Added `flags=` prefix to the __str__ implementation.

#### Cute Animal Picture


![funny-cats-dogs-stuck-furniture-1](https://user-images.githubusercontent.com/824194/73700014-96fc8800-46a2-11ea-963e-5a470f5bac46.jpg)
