### PR TITLE
Fix task cancellation when the Service.run() crashes or a daemon task exits

### DIFF
--- a/async_service/abc.py
+++ b/async_service/abc.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Hashable, Optional
+from typing import Any, Hashable, Optional, Set
 
 import trio_typing
 
@@ -11,6 +11,7 @@ class TaskAPI(Hashable):
     name: str
     daemon: bool
     parent: Optional["TaskAPI"]
+    children: Set["TaskAPI"]
 
     @abstractmethod
     def add_child(self, child: "TaskAPI") -> None:

--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -134,9 +134,10 @@ class AsyncioManager(BaseManager):
         for task in tuple(self._root_tasks):
             try:
                 self.logger.debug(
-                    "%s: triggering cancellation of root task %s and all its children",
+                    "%s: triggering cancellation of root task %s and all its children (%s)",
                     self,
                     task.name,
+                    [c.name for c in task.children],
                 )
                 await task.cancel()
                 self.logger.debug("%s: cancelled %s", self, task.name)
@@ -168,7 +169,7 @@ class AsyncioManager(BaseManager):
         while self._asyncio_tasks:
             done_tasks = tuple(task for task in self._asyncio_tasks if task.done())
             for task in done_tasks:
-                self.logger.debug("%s: waiting for %s to finish", task)
+                self.logger.debug("%s: waiting for %s to finish", self, task)
                 try:
                     await task
                 except asyncio.CancelledError:

--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -133,7 +133,13 @@ class AsyncioManager(BaseManager):
         # cancelled as part of the global task nursery's cancellation.
         for task in tuple(self._root_tasks):
             try:
+                self.logger.debug(
+                    "%s: triggering cancellation of root task %s and all its children",
+                    self,
+                    task.name,
+                )
                 await task.cancel()
+                self.logger.debug("%s: cancelled %s", self, task.name)
             except Exception:
                 self._errors.append(cast(EXC_INFO, sys.exc_info()))
 
@@ -162,6 +168,7 @@ class AsyncioManager(BaseManager):
         while self._asyncio_tasks:
             done_tasks = tuple(task for task in self._asyncio_tasks if task.done())
             for task in done_tasks:
+                self.logger.debug("%s: waiting for %s to finish", task)
                 try:
                     await task
                 except asyncio.CancelledError:

--- a/async_service/base.py
+++ b/async_service/base.py
@@ -318,8 +318,11 @@ class BaseManager(InternalManagerAPI):
             self._errors.append(cast(EXC_INFO, sys.exc_info()))
             self.cancel()
         else:
+            if task.parent is None:
+                # XXX: I believe that by removing root tasks from self._root_tasks we will no
+                # longer trigger cancellation of any of its children upon service cancellation,
+                # which will in turn cause the manager to hang forever.
+                self._root_tasks.remove(task)
             self.logger.debug("%s: task %s finished.", self, task)
         finally:
-            if task.parent is None:
-                self._root_tasks.remove(task)
             self._done_task_count += 1

--- a/tests-asyncio/test_asyncio_based_service.py
+++ b/tests-asyncio/test_asyncio_based_service.py
@@ -187,6 +187,17 @@ async def test_asyncio_service_lifecycle_run_and_daemon_task_exit():
 
 
 @pytest.mark.asyncio
+async def test_error_in_service_run():
+    class ServiceTest(Service):
+        async def run(self):
+            self.manager.run_daemon_task(self.manager.wait_finished)
+            raise ValueError("Exception inside run()")
+
+    with pytest.raises(ValueError):
+        await AsyncioManager.run_service(ServiceTest())
+
+
+@pytest.mark.asyncio
 async def test_multierror_in_run():
     # This test should cause ServiceTest to raise a trio.MultiError containing two exceptions --
     # one raised inside its run() method and another raised by the daemon task exiting early.


### PR DESCRIPTION
In some cases an exception raised in Service.run() can cause the manager to hang forever waiting for all tasks to complete. Specifically, when run() schedules a daemon task and then raises an exception itself, this would happen:

 - _run_and_manage_task() catches the exception, then:
   - stores it in self._errors
   - triggers the service cancellation, and
   - removes the run() task from self._root_tasks
 - _handle_cancelled() kicks in
   - iterates over empty self._root_tasks, so doesn't cancel anything.
   - raise a LifecycleError because the daemon task is not done yet
 - _wait_all_tasks_done() never returns, so manager.run() doesn't either

This fixes that by changing _run_and_manage_task() to not remove root tasks from self._root_tasks

Also, if a daemon task exits leaving children behind, those would end up orphaned and would cause the service to hang upon cancellation.