### PR TITLE
Fix a bug from last commit and log exceptions in _handle_cancelled()

### DIFF
--- a/async_service/abc.py
+++ b/async_service/abc.py
@@ -10,16 +10,7 @@ from .typing import AsyncFn
 class TaskAPI(Hashable):
     name: str
     daemon: bool
-    parent: Optional["TaskAPI"]
-    children: Set["TaskAPI"]
-
-    @abstractmethod
-    def add_child(self, child: "TaskAPI") -> None:
-        ...
-
-    @abstractmethod
-    def discard_child(self, child: "TaskAPI") -> None:
-        ...
+    parent: Optional["TaskWithChildrenAPI"]
 
     @abstractmethod
     async def run(self) -> None:
@@ -36,6 +27,18 @@ class TaskAPI(Hashable):
 
     @abstractmethod
     async def wait_done(self) -> None:
+        ...
+
+
+class TaskWithChildrenAPI(TaskAPI):
+    children: Set[TaskAPI]
+
+    @abstractmethod
+    def add_child(self, child: TaskAPI) -> None:
+        ...
+
+    @abstractmethod
+    def discard_child(self, child: TaskAPI) -> None:
         ...
 
 

--- a/async_service/trio.py
+++ b/async_service/trio.py
@@ -19,7 +19,7 @@ import trio
 import trio_typing
 
 from ._utils import get_task_name
-from .abc import ManagerAPI, ServiceAPI, TaskAPI
+from .abc import ManagerAPI, ServiceAPI, TaskAPI, TaskWithChildrenAPI
 from .base import BaseChildServiceTask, BaseFunctionTask, BaseManager
 from .exceptions import DaemonTaskExit, LifecycleError
 from .typing import EXC_INFO, AsyncFn
@@ -32,7 +32,7 @@ class FunctionTask(BaseFunctionTask):
         self,
         name: str,
         daemon: bool,
-        parent: Optional[TaskAPI],
+        parent: Optional[TaskWithChildrenAPI],
         async_fn: AsyncFn,
         async_fn_args: Sequence[Any],
     ) -> None:
@@ -103,7 +103,7 @@ class ChildServiceTask(BaseChildServiceTask):
         self,
         name: str,
         daemon: bool,
-        parent: Optional[TaskAPI],
+        parent: Optional[TaskWithChildrenAPI],
         child_service: ServiceAPI,
     ) -> None:
         super().__init__(name, daemon, parent)
@@ -244,7 +244,9 @@ class TrioManager(BaseManager):
     async def wait_finished(self) -> None:
         await self._finished.wait()
 
-    def _find_parent_task(self, trio_task: trio.hazmat.Task) -> Optional[TaskAPI]:
+    def _find_parent_task(
+        self, trio_task: trio.hazmat.Task
+    ) -> Optional[TaskWithChildrenAPI]:
         """
         Find the :class:`async_service.trio.FunctionTask` instance that corresponds to
         the given :class:`trio.hazmat.Task` instance.


### PR DESCRIPTION
The last commit moved the children attribute from BaseFunctionTask to
TaskAPI as the latter had methods for dealing with children so it
seemed like a more appropriate place for that. However, that was
misleading as although ChildServiceTask inherited from TaskAPI,
it didn't support children and its children-related methods would
raise NotImplementedError. Now we have TaskAPI and TaskWithChildrenAPI
classes and the children attribute and related methods are in the
latter.

The last commit had also introduced some changes to log extra info in
_handle_cancelled(), but that would crash when the task didn't support
children, which would in turn leave dangling tasks that would prevent
Manager.run() from finishing and the error from being reported. This has
also been fixed by always immediately logging errors from
_handle_cancelled().