### PR TITLE
Improved logging, and gathering children in parellel

### DIFF
--- a/async_service/_utils.py
+++ b/async_service/_utils.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, TypeVar
 
 TItem = TypeVar("TItem")
@@ -30,3 +31,7 @@ def get_task_name(value: Any, explicit_name: str = None) -> str:
             return str(value.__name__)  # mypy doesn't know __name__ is a `str`
         except AttributeError:
             return repr(value)
+
+
+def is_verbose_logging_enabled() -> bool:
+    return bool(os.environ.get("ASYNC_SERVICE_VERBOSE_LOG", False))

--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -190,7 +190,8 @@ class AsyncioManager(BaseManager):
         while self._asyncio_tasks:
             done_tasks = tuple(task for task in self._asyncio_tasks if task.done())
             for task in done_tasks:
-                self.logger.debug("%s: waiting for %s to finish", self, task)
+                if self._verbose:
+                    self.logger.debug("%s: waiting for %s to finish", self, task)
                 try:
                     await task
                 except asyncio.CancelledError:

--- a/async_service/asyncio.py
+++ b/async_service/asyncio.py
@@ -37,7 +37,15 @@ class FunctionTask(BaseFunctionTask):
                 raise DaemonTaskExit(f"Daemon task {self} exited")
 
             while self.children:
-                await tuple(self.children)[0].wait_done()
+                # copy, because children can change size
+                active_children = tuple(self.children)
+                # Children will be removed from the list as they exit. Here,
+                #   we just want to check if the list is empty, but to wait until
+                #   at least one child has finished.
+                # There is some intuition that gather()-ing all the children
+                #   adds more overhead than the following approach of just waiting
+                #   for a single random-ish child to exit.
+                await active_children[0].wait_done()
         finally:
             if self.parent is not None:
                 self.parent.discard_child(self)

--- a/async_service/base.py
+++ b/async_service/base.py
@@ -328,7 +328,7 @@ class BaseManager(InternalManagerAPI):
             self.logger.debug("%s: task %s raised CancelledError.", self, task)
             raise
         except Exception as err:
-            self.logger.debug(
+            self.logger.error(
                 "%s: task %s exited with error: %s",
                 self,
                 task,

--- a/async_service/base.py
+++ b/async_service/base.py
@@ -17,6 +17,7 @@ from typing import (
 )
 import uuid
 
+from ._utils import is_verbose_logging_enabled
 from .abc import (
     InternalManagerAPI,
     ManagerAPI,
@@ -181,6 +182,7 @@ class BaseChildServiceTask(BaseTask):
 
 class BaseManager(InternalManagerAPI):
     logger = logging.getLogger("async_service.Manager")
+    _verbose = is_verbose_logging_enabled()
 
     _service: ServiceAPI
 
@@ -282,18 +284,23 @@ class BaseManager(InternalManagerAPI):
             return
 
         if task.parent is None:
-            self.logger.debug("%s: running root task %s", self, task)
+            if self._verbose:
+                self.logger.debug("%s: running root task %s", self, task)
             self._root_tasks.add(task)
         else:
+            if self._verbose:
+                self.logger.debug(
+                    "%s: %s running child task %s", self, task.parent, task
+                )
             task.parent.add_child(task)
-            self.logger.debug("%s: %s running child task %s", self, task.parent, task)
 
         self._total_task_count += 1
 
         self._schedule_task(task)
 
     async def _run_and_manage_task(self, task: TaskAPI) -> None:
-        self.logger.debug("%s: task %s running", self, task)
+        if self._verbose:
+            self.logger.debug("%s: task %s running", self, task)
 
         try:
             try:
@@ -334,6 +341,7 @@ class BaseManager(InternalManagerAPI):
         else:
             if task.parent is None:
                 self._root_tasks.remove(task)
-            self.logger.debug("%s: task %s exited cleanly.", self, task)
+            if self._verbose:
+                self.logger.debug("%s: task %s exited cleanly.", self, task)
         finally:
             self._done_task_count += 1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
         "black==19.3b",
         "flake8==3.7.9",
         "isort>=4.2.15,<5",
-        "mypy==0.740",
+        "mypy==0.782",
         "pydocstyle>=3.0.0,<4",
     ],
     'doc': [


### PR DESCRIPTION
## What was wrong?

- Logs are very noisy
- Uncaught exception log was emitted as debug, easy to miss
- Unexpected way to gather children
- ~asyncio reports slow coros as originating in async-service, making it difficult to debug~

## How was it fixed?

- Remove debug logs that are happening a ton (there is no DEBUG2 here)
- Upgrade log level to error
- Break up line in two, comment it
- ~name the task before running it~ _Was causing a difficult bug_

TODO:
- [x] make it friendly to py <3.8

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/83/08/1e/83081eff874c3ea25e2bbd3e7fe12a7e.jpg)
