### PR TITLE
Raise exception when starting too many children

### DIFF
--- a/async_service/__init__.py
+++ b/async_service/__init__.py
@@ -5,7 +5,11 @@ from .asyncio import (  # noqa: F401
     external_api as external_asyncio_api,
 )
 from .base import Service, as_service  # noqa: F401
-from .exceptions import DaemonTaskExit, LifecycleError  # noqa: F401
+from .exceptions import (  # noqa: F401
+    DaemonTaskExit,
+    LifecycleError,
+    TooManyChildrenException,
+)
 from .trio import (  # noqa: F401
     TrioManager,
     background_trio_service,

--- a/async_service/exceptions.py
+++ b/async_service/exceptions.py
@@ -20,3 +20,12 @@ class DaemonTaskExit(ServiceException):
     """
 
     pass
+
+
+class TooManyChildrenException(ServiceException):
+    """
+    Raised when a service adds too many children. It is a sign of task leakage
+    that needs to be prevented.
+    """
+
+    pass


### PR DESCRIPTION
## What was wrong?

Too many active coroutines are bound to slow down the event loop. We want to know when too many tasks are started, and what those tasks are.

## How was it fixed?

When >1000 children are added to a service, we raise an exception, with some information on the most common active tasks.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/2c/5e/b5/2c5eb501343ebd2b34f841cd3ca7b87b.jpg)
